### PR TITLE
Support for returning String from PrintingVisitor

### DIFF
--- a/src/main/java/de/danielbechler/diff/visitor/ToStringVisitor.java
+++ b/src/main/java/de/danielbechler/diff/visitor/ToStringVisitor.java
@@ -1,0 +1,23 @@
+package de.danielbechler.diff.visitor;
+
+import de.danielbechler.diff.visitor.PrintingVisitor;
+
+public class ToStringVisitor extends PrintingVisitor
+{
+	String	string;
+
+	public ToStringVisitor(Object working, Object base)
+	{
+		super(working, base);
+	}
+
+	protected void print(final String text)
+	{
+		string = text;
+	}
+
+	public String getString()
+	{
+		return string;
+	}
+}


### PR DESCRIPTION
The PrintingVisitor's output is fantastic. We have found use for java-object-diff in our project while writing unit tests.
Instead of requiring intricate coding to determine the diff or letting the developer infer the problem from the sys.out having the PrintingVisitor's output really helps.

Typically while writing units tests, the error messages are printed using:
Assert.equals(expected, actual, "message")

It will be great if we can pass PrintingVisitor's output to Assert.

This pull request contains one possible solution for the problem. Here I have created a ToStringVisitor subclasses PrintingVisitor and collects the string output in a local field instead of sending the output to the console.

One drawback of this approach though is that the caller can no longer access this Visitor using the Node.Visitor interface.
