### PR TITLE
Features/use comparator

### DIFF
--- a/src/main/java/de/danielbechler/diff/BeanDiffer.java
+++ b/src/main/java/de/danielbechler/diff/BeanDiffer.java
@@ -72,18 +72,18 @@ final class BeanDiffer implements Differ<Node>
 
 	private void compareUsingAppropriateMethod(final Node beanNode, final Instances instances)
 	{
-		if (nodeInspector.isIntrospectible(beanNode))
+		if (nodeInspector.isCompareToOnly(beanNode))
 		{
-			compareUsingIntrospection(beanNode, instances);
-		}
-		else if (nodeInspector.isComparable(beanNode))
-		{
-			compareUsingCompare(beanNode, instances);
+			compareUsingCompareTo(beanNode, instances);
 		}
 		else if (nodeInspector.isEqualsOnly(beanNode))
 		{
 			compareUsingEquals(beanNode, instances);
 		}
+        else if (nodeInspector.isIntrospectible(beanNode))
+        {
+            compareUsingIntrospection(beanNode, instances);
+        }
 	}
 
 	private void compareUsingIntrospection(final Node beanNode, final Instances beanInstances)
@@ -100,22 +100,23 @@ final class BeanDiffer implements Differ<Node>
 		}
 	}
 
+    @SuppressWarnings({"MethodMayBeStatic"})
+    private void compareUsingCompareTo(final Node beanNode, final Instances instances)
+    {
+        if (instances.areEqualByComparison())
+        {
+            beanNode.setState(Node.State.UNTOUCHED);
+        }
+        else
+        {
+            beanNode.setState(Node.State.CHANGED);
+        }
+    }
+
 	@SuppressWarnings({"MethodMayBeStatic"})
 	private void compareUsingEquals(final Node beanNode, final Instances instances)
 	{
 		if (instances.areEqual())
-		{
-			beanNode.setState(Node.State.UNTOUCHED);
-		}
-		else
-		{
-			beanNode.setState(Node.State.CHANGED);
-		}
-	}
-
-	private void compareUsingCompare(final Node beanNode, final Instances instances)
-	{
-		if (instances.areComparable())
 		{
 			beanNode.setState(Node.State.UNTOUCHED);
 		}

--- a/src/main/java/de/danielbechler/diff/Instances.java
+++ b/src/main/java/de/danielbechler/diff/Instances.java
@@ -25,6 +25,7 @@ import de.danielbechler.util.Collections;
 import java.util.*;
 
 import static de.danielbechler.util.Objects.*;
+import static de.danielbechler.util.Comparables.*;
 
 /** @author Daniel Bechler */
 @SuppressWarnings({"UnusedDeclaration"})
@@ -172,14 +173,10 @@ class Instances
 		return isEqual(base, working);
 	}
 
-    public boolean areComparable()
+    public boolean areEqualByComparison()
 	{
-		return areComparable((Comparable) base, (Comparable) working);
+		return isEqualByComparison((Comparable) base, (Comparable) working);
 	}
-
-    private boolean areComparable(Comparable base, Comparable working) {
-        return base.compareTo(working) == 0;
-    }
 
     public boolean areSame()
 	{

--- a/src/main/java/de/danielbechler/util/Classes.java
+++ b/src/main/java/de/danielbechler/util/Classes.java
@@ -19,6 +19,7 @@ package de.danielbechler.util;
 import org.slf4j.*;
 
 import java.lang.reflect.*;
+import java.math.BigDecimal;
 import java.net.*;
 import java.util.*;
 
@@ -96,6 +97,11 @@ public final class Classes
 				URL.class.equals(clazz) ||
 				Locale.class.equals(clazz) ||
 				Class.class.equals(clazz);
+	}
+
+	public static boolean isComparableType(final Class<?> clazz)
+	{
+		return BigDecimal.class.equals(clazz);
 	}
 
 	public static <T> T freshInstanceOf(final Class<T> clazz)

--- a/src/main/java/de/danielbechler/util/Comparables.java
+++ b/src/main/java/de/danielbechler/util/Comparables.java
@@ -14,29 +14,25 @@
  * limitations under the License.
  */
 
-package de.danielbechler.diff;
-
-import de.danielbechler.diff.node.*;
+package de.danielbechler.util;
 
 /** @author Daniel Bechler */
-interface NodeInspector
+public class Comparables
 {
-	boolean isIgnored(Node node);
+	private Comparables()
+	{
+	}
 
-	boolean isIncluded(Node node);
-
-	boolean isExcluded(Node node);
-
-    boolean isCompareToOnly(Node node);
-
-	boolean isEqualsOnly(Node node);
-
-	boolean isReturnable(Node node);
-
-	/**
-	 * @return Returns <code>true</code> if the object represented by the given node should be compared via
-	 *         introspection. It must always return </code><code>false</code> if {@link
-	 *         #isEqualsOnly(de.danielbechler.diff.node.Node)} returns <code>true</code>.
-	 */
-	boolean isIntrospectible(Node node);
+	public static <T extends Comparable<T>> boolean isEqualByComparison(final T a, final T b)
+	{
+		if (a != null)
+		{
+			return a.compareTo(b) == 0;
+		}
+		else if (b != null)
+		{
+			return b.compareTo(a) == 0;
+		}
+		return true;
+	}
 }

--- a/src/test/java/de/danielbechler/diff/BeanDifferShould.java
+++ b/src/test/java/de/danielbechler/diff/BeanDifferShould.java
@@ -24,8 +24,6 @@ import de.danielbechler.diff.path.*;
 import org.mockito.Mock;
 import org.testng.annotations.*;
 
-import java.math.BigDecimal;
-
 import static de.danielbechler.diff.node.NodeAssertions.assertThat;
 import static java.util.Arrays.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -99,6 +97,18 @@ public class BeanDifferShould
 		assertThat(node).self().hasState(Node.State.IGNORED);
 	}
 
+    @Test
+    public void compare_bean_via_compare_to()
+    {
+        final ObjectWithCompareTo working = new ObjectWithCompareTo("foo", "ignore");
+        final ObjectWithCompareTo base = new ObjectWithCompareTo("foo", "ignore this too");
+        configuration.withCompareToOnlyType(ObjectWithCompareTo.class);
+
+        final Node node = differ.compare(Node.ROOT, Instances.of(working, base));
+
+        assertThat(node).self().isUntouched();
+    }
+
 	@Test
 	public void compare_bean_via_equals()
 	{
@@ -110,32 +120,6 @@ public class BeanDifferShould
 
 		assertThat(node).self().isUntouched();
 	}
-
-	@Test
-	public void compare_bean_via_comparable_when_same_value()
-	{
-		final BigDecimal working = new BigDecimal("1.0");
-		final BigDecimal base = new BigDecimal("1.00");
-		configuration.withComparableType(BigDecimal.class);
-
-		final Node node = differ.compare(Node.ROOT, Instances.of(working, base));
-
-		assertThat(node).self().isUntouched();
-	}
-
-	@Test
-	public void compare_bean_via_comparable_when_different_value()
-	{
-		final BigDecimal working = new BigDecimal("1.0");
-		final BigDecimal base = new BigDecimal("1.01");
-		configuration.withComparableType(BigDecimal.class);
-
-		final Node node = differ.compare(Node.ROOT, Instances.of(working, base));
-
-		assertThat(node).self().hasChanges();
-	}
-
-
 
 	@Test
 	public void compare_bean_via_introspection_and_delegate_comparison_of_properties()

--- a/src/test/java/de/danielbechler/diff/ConfigurationTest.java
+++ b/src/test/java/de/danielbechler/diff/ConfigurationTest.java
@@ -24,6 +24,8 @@ import org.mockito.invocation.*;
 import org.mockito.stubbing.*;
 import org.testng.annotations.*;
 
+import java.math.BigDecimal;
+
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.*;
@@ -98,6 +100,35 @@ public class ConfigurationTest
 		assertThat(configuration.isIgnored(node), is(true));
 	}
 
+    @SuppressWarnings({"unchecked"})
+    @Test
+    public void testIsCompareToOnlyWithConfiguredPropertyType() throws Exception
+    {
+        final Class aClass = ObjectWithStringAndCompareTo.class;
+        when(node.getType()).thenReturn(aClass);
+        configuration.withCompareToOnlyType(aClass);
+        assertThat(configuration.isCompareToOnly(node), is(true));
+    }
+
+    @SuppressWarnings({"unchecked"})
+    @Test
+    public void testIsCompareToOnlyWithConfiguredPropertyTypeNotComparable() throws Exception
+    {
+        final Class aClass = ObjectWithString.class;
+        when(node.getType()).thenReturn(aClass);
+        configuration.withCompareToOnlyType(aClass);
+        assertThat(configuration.isCompareToOnly(node), is(false));
+    }
+
+    @SuppressWarnings({"unchecked"})
+    @Test
+    public void testIsCompareToOnlyWithComparableType() throws Exception
+    {
+        final Class aClass = BigDecimal.class;
+        when(node.getType()).thenReturn(aClass);
+        assertThat(configuration.isCompareToOnly(node), is(true));
+    }
+
 	@Test
 	public void testIsEqualsOnlyWithConfiguredPropertyPath() throws Exception
 	{
@@ -143,13 +174,6 @@ public class ConfigurationTest
 	}
 
 	@Test
-	public void testIsIntrospectibleWithEqualsOnlyNodeReturnsFalse()
-	{
-		when(node.getType()).then(returnClass(String.class));
-		assertThat(configuration.isIntrospectible(node)).isFalse();
-	}
-
-	@Test
 	public void testIsIntrospectibleWithUntouchedNonEqualsOnlyNodeReturnsFalse()
 	{
 		when(node.getType()).then(returnClass(ObjectWithString.class));
@@ -188,34 +212,6 @@ public class ConfigurationTest
 		when(node.isRemoved()).thenReturn(true);
 		assertThat(configuration.isIntrospectible(node)).isFalse();
 	}
-
-    @Test
-    public void testIsComparableWithAComparableObjectAddedInConfiguration() throws Exception
-    {
-        final Class aClass = ObjectImplementComparable.class;
-        this.configuration.withComparableType(aClass);
-        when(node.getType()).thenReturn(aClass);
-
-        assertThat(this.configuration.isComparable(node), is(true));
-    }
-
-    @Test
-    public void testIsComparableWithAComparableObjectNotAddedInConfiguration() throws Exception
-    {
-        final Class aClass = ObjectImplementComparable.class;
-        when(node.getType()).thenReturn(aClass);
-
-        assertThat(this.configuration.isComparable(node), is(false));
-    }
-
-    @Test
-    public void testIsNotComparableWithANotComparableObject() throws Exception
-    {
-        final Class aClass = Object.class;
-        when(node.getType()).thenReturn(aClass);
-
-        assertThat(this.configuration.isComparable(node), is(false));
-    }
 
     @SuppressWarnings({"TypeMayBeWeakened"})
 	private static <T> Answer<Class<T>> returnClass(final Class<T> aClass)

--- a/src/test/java/de/danielbechler/diff/mock/ObjectImplementComparable.java
+++ b/src/test/java/de/danielbechler/diff/mock/ObjectImplementComparable.java
@@ -1,9 +1,0 @@
-package de.danielbechler.diff.mock;
-
-public class ObjectImplementComparable implements Comparable<ObjectImplementComparable> {
-
-    public int compareTo(ObjectImplementComparable o) {
-        return 0;
-    }
-
-}

--- a/src/test/java/de/danielbechler/diff/mock/ObjectWithCompareTo.java
+++ b/src/test/java/de/danielbechler/diff/mock/ObjectWithCompareTo.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2012 Daniel Bechler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.danielbechler.diff.mock;
+
+import de.danielbechler.util.Assert;
+
+/** @author Daniel Bechler */
+public class ObjectWithCompareTo implements Comparable<ObjectWithCompareTo>
+{
+	private final String key;
+
+	private String value;
+	private ObjectWithCompareTo item;
+
+	public ObjectWithCompareTo(final String key)
+	{
+		Assert.hasText(key, "key");
+		this.key = key;
+	}
+
+	public ObjectWithCompareTo(final String key, final String value)
+	{
+		this(key);
+		this.value = value;
+	}
+
+	public String getKey()
+	{
+		return key;
+	}
+
+	public String getValue()
+	{
+		return value;
+	}
+
+	public void setValue(final String value)
+	{
+		this.value = value;
+	}
+
+	public ObjectWithCompareTo getItem()
+	{
+		return item;
+	}
+
+	public ObjectWithCompareTo setItem(final ObjectWithCompareTo item)
+	{
+		this.item = item;
+		return this;
+	}
+
+    public int compareTo(ObjectWithCompareTo objectWithCompareTo) {
+        return this.key.compareTo(objectWithCompareTo.key);
+    }
+}

--- a/src/test/java/de/danielbechler/diff/mock/ObjectWithStringAndCompareTo.java
+++ b/src/test/java/de/danielbechler/diff/mock/ObjectWithStringAndCompareTo.java
@@ -14,29 +14,36 @@
  * limitations under the License.
  */
 
-package de.danielbechler.diff;
-
-import de.danielbechler.diff.node.*;
+package de.danielbechler.diff.mock;
 
 /** @author Daniel Bechler */
-interface NodeInspector
+@SuppressWarnings({
+		"UnusedDeclaration"
+})
+public class ObjectWithStringAndCompareTo implements Comparable<ObjectWithStringAndCompareTo>
 {
-	boolean isIgnored(Node node);
+	private String value;
 
-	boolean isIncluded(Node node);
+	public ObjectWithStringAndCompareTo()
+	{
+	}
 
-	boolean isExcluded(Node node);
+	public ObjectWithStringAndCompareTo(final String value)
+	{
+		this.value = value;
+	}
 
-    boolean isCompareToOnly(Node node);
+	public String getValue()
+	{
+		return value;
+	}
 
-	boolean isEqualsOnly(Node node);
+	public void setValue(final String value)
+	{
+		this.value = value;
+	}
 
-	boolean isReturnable(Node node);
-
-	/**
-	 * @return Returns <code>true</code> if the object represented by the given node should be compared via
-	 *         introspection. It must always return </code><code>false</code> if {@link
-	 *         #isEqualsOnly(de.danielbechler.diff.node.Node)} returns <code>true</code>.
-	 */
-	boolean isIntrospectible(Node node);
+    public int compareTo(ObjectWithStringAndCompareTo objectWithStringAndCompareTo) {
+        return this.value.compareTo(objectWithStringAndCompareTo.value);
+    }
 }


### PR DESCRIPTION
Hi, 

The comparaison between BigDecimal with the equals method is different of comparaison with compareTo method. The equals method compare the value and the scale. For example, with BigDecimal, 1 is not equal to 1.0. This problem must be resolve using the compareTo method.

In this pull request, we add configuration and annotation to specify if an object must be comparing with equals or with compareTo method. We update the code to use compareTo instead of equals for BigDecimal.

Jean-Eudes
