### PR TITLE
Allow for checking field level annotations from DiffNode (getFieldAnn…

### DIFF
--- a/src/main/java/de/danielbechler/diff/node/DiffNode.java
+++ b/src/main/java/de/danielbechler/diff/node/DiffNode.java
@@ -444,6 +444,37 @@ public class DiffNode
 	}
 
 	/**
+	 * If this node represents a bean property this method returns all annotations of its field.
+	 *
+	 * Only works for fields having a name that matches the name derived from the getter.
+	 *
+	 * @return The annotations of the field, or an empty set if there is no field with the name derived from the getter.
+	 */
+	public Set<Annotation> getFieldAnnotations()
+	{
+		if (accessor instanceof PropertyAwareAccessor)
+		{
+			return unmodifiableSet(((PropertyAwareAccessor) accessor).getFieldAnnotations());
+		}
+		return unmodifiableSet(Collections.<Annotation>emptySet());
+	}
+
+	/**
+	 * @param annotationClass the annotation we are looking for
+	 * @param <T>
+	 * @return The given annotation of the field, or null if not annotated or if there is no field with the name derived
+	 * from the getter.
+	 */
+	public <T extends Annotation> T getFieldAnnotation(final Class<T> annotationClass)
+	{
+		if (accessor instanceof PropertyAwareAccessor)
+		{
+			return ((PropertyAwareAccessor) accessor).getFieldAnnotation(annotationClass);
+		}
+		return null;
+	}
+
+	/**
 	 * If this node represents a bean property this method returns all annotations of its getter.
 	 *
 	 * @return A set of annotations of this nodes property getter or an empty set.

--- a/src/test/java/de/danielbechler/diff/node/DiffNodeFieldAnnotationsTest.groovy
+++ b/src/test/java/de/danielbechler/diff/node/DiffNodeFieldAnnotationsTest.groovy
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2014 Daniel Bechler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.danielbechler.diff.node
+
+import de.danielbechler.diff.access.Accessor
+import de.danielbechler.diff.introspection.PropertyAccessor
+import de.danielbechler.diff.selector.BeanPropertyElementSelector
+import spock.lang.Specification
+
+class DiffNodeFieldAnnotationsTest extends Specification {
+
+	def 'getFieldAnnotation(): returns null if not PropertyAwareAccessor'() {
+		given:
+            def accessor = Mock(Accessor) {
+                getElementSelector() >> new BeanPropertyElementSelector('f')
+            }
+		    def diffNode = new DiffNode(null, accessor, A)
+		expect:
+			diffNode.fieldAnnotations.size() == 0
+		    diffNode.getFieldAnnotation(SomeFieldAnnotation) == null
+	}
+
+	def 'getFieldAnnotation(): class has the field and annotated'() {
+		given:
+			def accessor = new PropertyAccessor("f", A.getMethod("getF"), A.getMethod("setF", String))
+			def diffNode = new DiffNode(null, accessor, A)
+		expect:
+			diffNode.fieldAnnotations.size() == 1
+			diffNode.getFieldAnnotation(SomeFieldAnnotation) != null
+			diffNode.getFieldAnnotation(SomeFieldAnnotation).annotationType() == SomeFieldAnnotation
+	}
+
+	def 'getFieldAnnotation(): class does not have the field, or different name'() {
+		given:
+            def accessor = new PropertyAccessor("F", ADiffName.getMethod("getF"), null)
+            def diffNode = new DiffNode(null, accessor, ADiffName)
+		expect:
+			diffNode.fieldAnnotations.size() == 0
+            diffNode.getFieldAnnotation(SomeFieldAnnotation) == null
+	}
+
+	def 'getFieldAnnotation(): inheritance'() {
+		given:
+		def accessor = new PropertyAccessor("f", AB.getMethod("getF"), AB.getMethod("setF", String))
+		def diffNode = new DiffNode(null, accessor, AB)
+		expect:
+		diffNode.fieldAnnotations.size() == 1
+		diffNode.getFieldAnnotation(SomeFieldAnnotation) != null
+		diffNode.getFieldAnnotation(SomeFieldAnnotation).annotationType() == SomeFieldAnnotation
+	}
+
+	def 'getFieldAnnotation(): inheritance, overridden getter'() {
+		given:
+		def accessor = new PropertyAccessor("f", ABGetter.getMethod("getF"), ABGetter.getMethod("setF", String))
+		def diffNode = new DiffNode(null, accessor, ABGetter)
+		expect:
+		diffNode.fieldAnnotations.size() == 1
+		diffNode.getFieldAnnotation(SomeFieldAnnotation) != null
+		diffNode.getFieldAnnotation(SomeFieldAnnotation).annotationType() == SomeFieldAnnotation
+	}
+
+	def 'getFieldAnnotation(): inheritance, not annotated'() {
+		given:
+		def accessor = new PropertyAccessor("f", NAB.getMethod("getF"), NAB.getMethod("setF", String))
+		def diffNode = new DiffNode(null, accessor, NAB)
+		expect:
+		diffNode.fieldAnnotations.size() == 0
+		diffNode.getFieldAnnotation(SomeFieldAnnotation) == null
+	}
+
+	def 'getFieldAnnotation(): inheritance, overridden getter, not annotated'() {
+		given:
+		def accessor = new PropertyAccessor("f", NABGetter.getMethod("getF"), NABGetter.getMethod("setF", String))
+		def diffNode = new DiffNode(null, accessor, NABGetter)
+		expect:
+		diffNode.fieldAnnotations.size() == 0
+		diffNode.getFieldAnnotation(SomeFieldAnnotation) == null
+	}
+
+	public static class A {
+		@SomeFieldAnnotation
+		String f;
+	}
+
+	public static class NA {
+		String f;
+	}
+
+    public static class ADiffName {
+        public String getF() {
+            return null;
+        }
+    }
+
+	public static class AB extends A {
+	}
+
+	public static class ABGetter extends A {
+		@Override
+		public String getF() {
+			return null;
+		}
+	}
+
+	public static class NAB extends NA {
+	}
+
+	public static class NABGetter extends NA {
+		@Override
+		public String getF() {
+			return null;
+		}
+	}
+
+}

--- a/src/test/java/de/danielbechler/diff/node/SomeFieldAnnotation.java
+++ b/src/test/java/de/danielbechler/diff/node/SomeFieldAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Daniel Bechler
+ * Copyright 2013 Daniel Bechler
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,23 +14,14 @@
  * limitations under the License.
  */
 
-package de.danielbechler.diff.access;
+package de.danielbechler.diff.node;
 
-import java.lang.annotation.Annotation;
-import java.util.Set;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-/**
- * @author Daniel Bechler
- */
-public interface PropertyAwareAccessor extends TypeAwareAccessor, CategoryAware, ExclusionAware
-{
-	String getPropertyName();
-
-	Set<Annotation> getFieldAnnotations();
-
-	<T extends Annotation> T getFieldAnnotation(Class<T> annotationClass);
-
-	Set<Annotation> getReadMethodAnnotations();
-
-	<T extends Annotation> T getReadMethodAnnotation(Class<T> annotationClass);
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface SomeFieldAnnotation {
 }


### PR DESCRIPTION
…otations() functions added, similarly to getPropertyAnnotations()).

It is important specially for handling JPA classes where annotations can be at both places.

An alternative for the user of the library would be to use DiffNode%getParentNode()%getValueType() and DiffNode%getPropertyName() to do the same without the getFieldAnnotations() functions.

The client may even use something like Jandex (https://github.com/wildfly/jandex).