### PR TITLE
First draft of IdentityStrategy

### DIFF
--- a/src/integration-test/java/de/danielbechler/diff/identity/IdentityStrategyConfigIT.groovy
+++ b/src/integration-test/java/de/danielbechler/diff/identity/IdentityStrategyConfigIT.groovy
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2015 Daniel Bechler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.danielbechler.diff.identity
+
+import de.danielbechler.diff.ObjectDifferBuilder
+import de.danielbechler.diff.comparison.IdentityStrategy
+import de.danielbechler.diff.node.DiffNode
+import de.danielbechler.diff.node.Visit
+import de.danielbechler.diff.path.NodePath
+import de.danielbechler.diff.selector.CollectionItemElementSelector
+import de.danielbechler.diff.selector.MapKeyElementSelector
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.ToString
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class IdentityStrategyConfigIT extends Specification {
+
+	def working = new Container(
+			productMap: [
+					"PROD1": new Product(
+							id: "PROD1",
+							code: "Code1",
+							productVersions: [
+									new ProductVersion(id: "ID1", code: "PVC1"),
+									new ProductVersion(id: "ID2", code: "PVC2")
+							]),
+					"PROD2": new Product(
+							id: "PROD2",
+							code: "Code2",
+							productVersions: [
+									new ProductVersion(id: "ID1", code: "PVC1"),
+									new ProductVersion(id: "ID2", code: "PVC2")
+							])
+			],
+			otherMap: [
+					"PROD1": new Product(
+							id: "PROD1",
+							code: "Code1",
+							productVersions: [
+									new ProductVersion(id: "ID1", code: "PVC1"),
+									new ProductVersion(id: "ID2", code: "PVC2")
+							]),
+					"PROD2": new Product(
+							id: "PROD2",
+							code: "Code2",
+							productVersions: [
+									new ProductVersion(id: "ID1", code: "PVC1"),
+									new ProductVersion(id: "ID2", code: "PVC2")
+							])
+			]
+	)
+
+	def base = new Container(
+			productMap: [
+					"PROD1": new Product(
+							id: "PROD1",
+							code: "Code1",
+							productVersions: [
+									new ProductVersion(id: "ID3", code: "PVC1"),
+									new ProductVersion(id: "ID4", code: "PVC2")
+							]),
+					"PROD2": new Product(
+							id: "PROD2",
+							code: "Code2",
+							productVersions: [
+									new ProductVersion(id: "ID3", code: "PVC1"),
+									new ProductVersion(id: "ID4", code: "PVC2")
+							])
+			],
+			otherMap: [
+					"PROD1": new Product(
+							id: "PROD1",
+							code: "Code1",
+							productVersions: [
+									new ProductVersion(id: "ID1", code: "PVC1"),
+									new ProductVersion(id: "ID2", code: "PVC2")
+							]),
+					"PROD2": new Product(
+							id: "PROD2",
+							code: "Code2",
+							productVersions: [
+									new ProductVersion(id: "ID1", code: "PVC1"),
+									new ProductVersion(id: "ID2", code: "PVC2")
+							])
+			]
+	)
+
+	def 'Without IdentityStrategy'() {
+		when:
+		  def node = ObjectDifferBuilder
+				  .startBuilding()
+				  .filtering().returnNodesWithState(DiffNode.State.UNTOUCHED).and()
+				  .build().compare(working, base);
+		then: "High level nodes all changed"
+		  // print(node, working, base)
+		  node.getChild("otherMap").untouched
+		  node.getChild("productMap").changed
+		  node.getChild("productMap").getChild(new MapKeyElementSelector("PROD1")).changed
+		  node.getChild("productMap").getChild(new MapKeyElementSelector("PROD1")).getChild("productVersions").changed
+		and: "ID1 and ID2 are ADDED"
+		  node.getChild("productMap").getChild(new MapKeyElementSelector("PROD1")).getChild("productVersions")
+				  .getChild(PV1Selector).added
+		  node.getChild("productMap").getChild(new MapKeyElementSelector("PROD1")).getChild("productVersions")
+				  .getChild(PV2Selector).added
+		and: "ID3 and ID4 are REMOVED"
+		  node.getChild("productMap").getChild(new MapKeyElementSelector("PROD1")).getChild("productVersions")
+				  .getChild(PV3Selector).removed
+		  node.getChild("productMap").getChild(new MapKeyElementSelector("PROD1")).getChild("productVersions")
+				  .getChild(PV4Selector).removed
+	}
+
+	def 'PropertyOfType configuration WITH IdentityStrategy'() {
+		when:
+		  def node = ObjectDifferBuilder
+				  .startBuilding()
+				  .comparison().ofCollectionItems(Product, "productVersions").toUse(codeIdentity).and()
+				  .filtering().returnNodesWithState(DiffNode.State.UNTOUCHED).and()
+				  .build().compare(working, base);
+		then: "High level nodes"
+		  // print(node, working, base)
+		  node.getChild("otherMap").untouched
+		  node.getChild("productMap").changed
+		  node.getChild("productMap").getChild(new MapKeyElementSelector("PROD1")).changed
+		  node.getChild("productMap").getChild(new MapKeyElementSelector("PROD1")).getChild("productVersions").changed
+		and: "ID1 and ID2 are CHANGED"
+		  node.getChild("productMap").getChild(new MapKeyElementSelector("PROD1")).getChild("productVersions")
+				  .getChild(PV1CodeSelector).changed
+		  node.getChild("productMap").getChild(new MapKeyElementSelector("PROD1")).getChild("productVersions")
+				  .getChild(PV1CodeSelector).changed
+		and: "id changed, code untouched"
+		  node.getChild("productMap").getChild(new MapKeyElementSelector("PROD1")).getChild("productVersions")
+				  .getChild(PV1CodeSelector).getChild("id").changed
+		  node.getChild("productMap").getChild(new MapKeyElementSelector("PROD1")).getChild("productVersions")
+				  .getChild(PV1CodeSelector).getChild("code").untouched
+	}
+
+	def 'OfNode configuration WITH IdentityStrategy'() {
+		when:
+		  def node = ObjectDifferBuilder
+				  .startBuilding()
+				  .comparison().ofCollectionItems(
+				  // this is not very useful without wildcards on maps and collections...
+				  NodePath.startBuilding().propertyName("productMap").mapKey("PROD1")
+						  .propertyName("productVersions").build()
+		  ).toUse(codeIdentity).and()
+				  .filtering().returnNodesWithState(DiffNode.State.UNTOUCHED).and()
+				  .build().compare(working, base);
+		then: "High level nodes"
+//            print(node, working, base)
+		  node.getChild("otherMap").untouched
+		  node.getChild("productMap").changed
+		  node.getChild("productMap").getChild(new MapKeyElementSelector("PROD1")).changed
+		  node.getChild("productMap").getChild(new MapKeyElementSelector("PROD1")).getChild("productVersions").changed
+		and: "ID1 and ID2 are CHANGED"
+		  node.getChild("productMap").getChild(new MapKeyElementSelector("PROD1")).getChild("productVersions")
+				  .getChild(PV1CodeSelector).changed
+		  node.getChild("productMap").getChild(new MapKeyElementSelector("PROD1")).getChild("productVersions")
+				  .getChild(PV1CodeSelector).changed
+		and: "id changed, code untouched"
+		  node.getChild("productMap").getChild(new MapKeyElementSelector("PROD1")).getChild("productVersions")
+				  .getChild(PV1CodeSelector).getChild("id").changed
+		  node.getChild("productMap").getChild(new MapKeyElementSelector("PROD1")).getChild("productVersions")
+				  .getChild(PV1CodeSelector).getChild("code").untouched
+	}
+
+
+	private void print(final DiffNode diffNode, final Object working,
+					   final Object base) {
+		diffNode.visit(new DiffNode.Visitor() {
+			@Override
+			void node(final DiffNode node, final Visit visit) {
+				System.out.println("" + node.getPath() + " " + node.getState()
+						// + " " + node.canonicalGet(base) + " => " + node.canonicalGet(working)
+				)
+			}
+		})
+	}
+
+
+	public static class Container {
+		Map<String, Product> productMap;
+		Map<String, Product> otherMap;
+	}
+
+	public static interface CodeId {
+		String getCode();
+	}
+
+	@EqualsAndHashCode(includes = ["id"])
+	@ToString(includePackage = false)
+	public static class Product implements CodeId {
+		String id;
+		String code;
+		List<ProductVersion> productVersions;
+		List<ProductVersion> others;
+	}
+
+	@EqualsAndHashCode(includes = ["id"])
+	@ToString(includePackage = false)
+	public static class ProductVersion implements CodeId {
+		String id;
+		String code;
+	}
+
+	@EqualsAndHashCode(includes = ["id"])
+	@ToString(includePackage = false)
+	public static class OtherClass implements CodeId {
+		String id;
+		String code;
+		List<ProductVersion> productVersions;
+	}
+
+	def codeIdentity = new IdentityStrategy() {
+		@Override
+		boolean equals(final Object working, final Object base) {
+			return Objects.equals(((CodeId) working).getCode(), ((CodeId) base).getCode());
+		}
+	}
+
+	def PV1Selector = new CollectionItemElementSelector(new ProductVersion(id: "ID1", code: "PVC1"));
+	def PV2Selector = new CollectionItemElementSelector(new ProductVersion(id: "ID2", code: "PVC2"));
+	def PV3Selector = new CollectionItemElementSelector(new ProductVersion(id: "ID3"));
+	def PV4Selector = new CollectionItemElementSelector(new ProductVersion(id: "ID4"));
+
+	// need to fill code as well because that's used for the codeIdentity cases
+	def PV1CodeSelector = new CollectionItemElementSelector(new ProductVersion(code: "PVC1"), codeIdentity);
+	def PV2CodeSelector = new CollectionItemElementSelector(new ProductVersion(code: "PVC2"), codeIdentity);
+}

--- a/src/integration-test/java/de/danielbechler/diff/identity/IdentityStrategyIT.groovy
+++ b/src/integration-test/java/de/danielbechler/diff/identity/IdentityStrategyIT.groovy
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2015 Daniel Bechler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.danielbechler.diff.identity
+
+import de.danielbechler.diff.ObjectDifferBuilder
+import de.danielbechler.diff.comparison.IdentityStrategy
+import de.danielbechler.diff.node.DiffNode
+import de.danielbechler.diff.node.Visit
+import de.danielbechler.diff.path.NodePath
+import de.danielbechler.diff.selector.CollectionItemElementSelector
+import spock.lang.Specification
+
+class IdentityStrategyIT extends Specification {
+
+    List<A> list1 = [
+            new A(id: "Id1", code: "Code1"),
+            new A(id: "Id2", code: "Code2"),
+            new A(id: "Id3", code: "Code3")
+    ]
+    List<A> list2 = [
+            new A(id: "Id1", code: "Code1"),
+            new A(id: "Id2", code: "Code2"),
+            new A(id: "Id3", code: "Code3")
+    ]
+    List<A> list2b = [
+            new A(id: "Id2", code: "Code2"),
+            new A(id: "Id3", code: "Code3"),
+            new A(id: "Id1", code: "Code1")
+    ]
+    List<A> list3 = [
+            new A(id: "Id1", code: "Code1"),
+            new A(id: "Id2", code: "newCode"),
+            new A(id: "newId", code: "Code2")
+    ]
+
+//    def 'Test default equals SAME'() {
+//        when:
+//        def diffNode = ObjectDifferBuilder.startBuilding()
+//                .build().compare(list2, list1)
+//        then:
+//        diffNode.untouched
+//    }
+//
+//    def 'Test default equals SAME B'() {
+//        when:
+//        def diffNode = ObjectDifferBuilder.startBuilding()
+//                .build().compare(list2b, list1)
+//        then:
+//        diffNode.untouched
+//    }
+//
+//    def 'Test default equals CHANGED'() {
+//        when:
+//        def diffNode = ObjectDifferBuilder.startBuilding()
+//                .build().compare(list3, list1)
+//        then:
+//        diffNode.changed
+//        diffNode.getChild(new CollectionItemElementSelector(new A(id: "Id1"))) == null
+//        diffNode.getChild(new CollectionItemElementSelector(new A(id: "Id2"))).changed
+//        diffNode.getChild(new CollectionItemElementSelector(new A(id: "newId"))).added
+//        diffNode.getChild(new CollectionItemElementSelector(new A(id: "Id3"))).removed
+//    }
+//
+//    def 'Test field CODE equals SAME'() {
+//        when:
+//        def diffNode = ObjectDifferBuilder.startBuilding()
+//                .comparison().ofType(A).toUseEqualsMethodOfValueProvidedByMethod("getCode").and()
+//                .build().compare(list2, list1)
+//        then:
+//        diffNode.state == DiffNode.State.UNTOUCHED
+//    }
+//
+//    def 'Test field CODE equals SAME B'() {
+//        when:
+//        def diffNode = ObjectDifferBuilder.startBuilding()
+//                .identity().ofType(A).toUse(new CodeIdentity()).and()
+//                .build().compare(list2b, list1)
+//        then:
+//        diffNode.state == DiffNode.State.UNTOUCHED
+//    }
+
+    def 'Test field CODE equals equals CHANGED'() {
+        when:
+        def codeStrategy = new CodeIdentity();
+        def diffNode = ObjectDifferBuilder.startBuilding()
+                .comparison().ofCollectionItems(NodePath.withRoot()) // TODO configuration shouldn't be like this!
+                .toUse(codeStrategy).and()
+                .build().compare(list3, list1)
+        then:
+        diffNode.state == DiffNode.State.CHANGED
+        diffNode.getChild(new CollectionItemElementSelector(new A(code: "Code1"), codeStrategy)) == null
+        diffNode.getChild(new CollectionItemElementSelector(new A(code: "newCode"), codeStrategy)).added
+        diffNode.getChild(new CollectionItemElementSelector(new A(code: "Code2"), codeStrategy)).changed
+        diffNode.getChild(new CollectionItemElementSelector(new A(code: "Code3"), codeStrategy)).removed
+    }
+
+    private void print(final DiffNode diffNode, final Object working,
+                       final Object base) {
+        diffNode.visit(new DiffNode.Visitor() {
+            @Override
+            void node(final DiffNode node, final Visit visit) {
+                System.out.println("" + node.getPath() + " " + node.getState() + " "
+                        + node.canonicalGet(base) + " => " + node.canonicalGet(working))
+            }
+        })
+    }
+
+    public static class A {
+        String id;
+        String code;
+
+        String getCode() {
+            return code
+        }
+
+        @Override
+        boolean equals(final o) {
+            if (this.is(o)) return true
+            if (!(o instanceof A)) return false
+
+            A a = (A) o
+
+            if (!Objects.equals(id, a.id)) return false
+
+            return true
+        }
+
+        @Override
+        int hashCode() {
+            return (id != null ? id.hashCode() : 0)
+        }
+    }
+
+    public static class CodeIdentity implements IdentityStrategy {
+        @Override
+        boolean equals(final Object working, final Object base) {
+            return Objects.equals(((A) working).getCode(), ((A) base).getCode());
+        }
+    }
+}

--- a/src/main/java/de/danielbechler/diff/ObjectDifferBuilder.java
+++ b/src/main/java/de/danielbechler/diff/ObjectDifferBuilder.java
@@ -45,9 +45,9 @@ import java.util.Collection;
 import java.util.Set;
 
 /**
- * This is the entry point of every diffing operation. It acts as a factory to get hold of an actual {@link
- * ObjectDiffer} instance and exposes a configuration API to customize its behavior to
- * suit your needs.
+ * This is the entry point of every diffing operation. It acts as a factory to
+ * get hold of an actual {@link ObjectDiffer} instance and exposes a
+ * configuration API to customize its behavior to suit your needs.
  *
  * @author Daniel Bechler
  */
@@ -67,40 +67,10 @@ public class ObjectDifferBuilder
 	{
 	}
 
-	public static ObjectDiffer buildDefault()
-	{
-		return startBuilding().build();
-	}
-
-	public ObjectDiffer build()
-	{
-		final DifferProvider differProvider = new DifferProvider();
-		final DifferDispatcher differDispatcher = new DifferDispatcher(
-				differProvider,
-				circularReferenceService,
-				circularReferenceService,
-				inclusionService,
-				returnableNodeService,
-				introspectionService);
-		differProvider.push(new BeanDiffer(differDispatcher, introspectionService, returnableNodeService, comparisonService, introspectionService));
-		differProvider.push(new CollectionDiffer(differDispatcher, comparisonService));
-		differProvider.push(new MapDiffer(differDispatcher, comparisonService));
-		differProvider.push(new PrimitiveDiffer(comparisonService));
-		for (final DifferFactory differFactory : differFactories)
-		{
-			differProvider.push(differFactory.createDiffer(differDispatcher, nodeQueryService));
-		}
-		return new ObjectDiffer(differDispatcher);
-	}
-
-	public static ObjectDifferBuilder startBuilding()
-	{
-		return new ObjectDifferBuilder();
-	}
-
 	/**
-	 * Allows to exclude nodes from being added to the object graph based on criteria that are only known after
-	 * the diff for the affected node and all its children has been determined.
+	 * Allows to exclude nodes from being added to the object graph based on
+	 * criteria that are only known after the diff for the affected node and all
+	 * its children has been determined.
 	 */
 	public FilteringConfigurer filtering()
 	{
@@ -108,7 +78,8 @@ public class ObjectDifferBuilder
 	}
 
 	/**
-	 * Allows to replace the default bean introspector with a custom implementation.
+	 * Allows to replace the default bean introspector with a custom
+	 * implementation.
 	 */
 	public IntrospectionConfigurer introspection()
 	{
@@ -116,7 +87,8 @@ public class ObjectDifferBuilder
 	}
 
 	/**
-	 * Allows to define how the circular reference detector compares object instances.
+	 * Allows to define how the circular reference detector compares object
+	 * instances.
 	 */
 	public CircularReferenceConfigurer circularReferenceHandling()
 	{
@@ -124,8 +96,8 @@ public class ObjectDifferBuilder
 	}
 
 	/**
-	 * Allows to in- or exclude nodes based on property name, object type, category or location in the object
-	 * graph.
+	 * Allows to in- or exclude nodes based on property name, object type,
+	 * category or location in the object graph.
 	 */
 	public InclusionConfigurer inclusion()
 	{
@@ -141,7 +113,8 @@ public class ObjectDifferBuilder
 	}
 
 	/**
-	 * Allows to assign custom categories (or tags) to entire types or selected elements and properties.
+	 * Allows to assign custom categories (or tags) to entire types or selected
+	 * elements and properties.
 	 */
 	public CategoryConfigurer categories()
 	{
@@ -151,6 +124,42 @@ public class ObjectDifferBuilder
 	public DifferConfigurer differs()
 	{
 		return differConfigurer;
+	}
+
+	public static ObjectDiffer buildDefault()
+	{
+		return startBuilding().build();
+	}
+
+	public ObjectDiffer build()
+	{
+		final DifferProvider differProvider = new DifferProvider();
+		final DifferDispatcher differDispatcher = new DifferDispatcher(
+				differProvider,
+				circularReferenceService,
+				circularReferenceService,
+				inclusionService,
+				returnableNodeService,
+				introspectionService);
+		differProvider.push(new BeanDiffer(
+				differDispatcher,
+				introspectionService,
+				returnableNodeService,
+				comparisonService,
+				introspectionService));
+		differProvider.push(new CollectionDiffer(differDispatcher, comparisonService, comparisonService));
+		differProvider.push(new MapDiffer(differDispatcher, comparisonService));
+		differProvider.push(new PrimitiveDiffer(comparisonService));
+		for (final DifferFactory differFactory : differFactories)
+		{
+			differProvider.push(differFactory.createDiffer(differDispatcher, nodeQueryService));
+		}
+		return new ObjectDiffer(differDispatcher);
+	}
+
+	public static ObjectDifferBuilder startBuilding()
+	{
+		return new ObjectDifferBuilder();
 	}
 
 	public class DifferConfigurerImpl implements DifferConfigurer
@@ -190,7 +199,8 @@ public class ObjectDifferBuilder
 			return comparisonService.resolveComparisonStrategy(node);
 		}
 
-		public PrimitiveDefaultValueMode resolvePrimitiveDefaultValueMode(final DiffNode node)
+		public PrimitiveDefaultValueMode resolvePrimitiveDefaultValueMode(
+				final DiffNode node)
 		{
 			return comparisonService.resolvePrimitiveDefaultValueMode(node);
 		}

--- a/src/main/java/de/danielbechler/diff/comparison/CollectionComparisonService.java
+++ b/src/main/java/de/danielbechler/diff/comparison/CollectionComparisonService.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2015 Daniel Bechler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.danielbechler.diff.comparison;
+
+import de.danielbechler.diff.inclusion.ValueNode;
+import de.danielbechler.diff.node.DiffNode;
+import de.danielbechler.diff.path.NodePath;
+
+public class CollectionComparisonService implements IdentityStrategyResolver
+{
+	private final ValueNode<IdentityStrategy> nodePathIdentityStrategies;
+	private final TypePropertyIdentityStrategyResolver typePropertyIdentityStrategyResolver;
+	private final ComparisonConfigurer comparisonConfigurer;
+
+	public CollectionComparisonService(final ComparisonConfigurer comparisonConfigurer)
+	{
+		this.comparisonConfigurer = comparisonConfigurer;
+		this.nodePathIdentityStrategies = new ValueNode<IdentityStrategy>();
+		this.typePropertyIdentityStrategyResolver = new TypePropertyIdentityStrategyResolver();
+	}
+
+	public IdentityStrategy resolveIdentityStrategy(final DiffNode node)
+	{
+		IdentityStrategy identityStrategy = typePropertyIdentityStrategyResolver.resolve(node);
+		if (identityStrategy != null)
+		{
+			return identityStrategy;
+		}
+		identityStrategy = nodePathIdentityStrategies.getNodeForPath(node.getPath()).getValue();
+		if (identityStrategy != null)
+		{
+			return identityStrategy;
+		}
+		return EqualsIdentityStrategy.getInstance();
+	}
+
+	public ComparisonConfigurer.OfCollectionItems ofCollectionItems(final NodePath nodePath)
+	{
+		return new OfCollectionItemsByNodePath(nodePath);
+	}
+
+	public ComparisonConfigurer.OfCollectionItems ofCollectionItems(final Class<?> type, final String propertyName)
+	{
+		return new OfCollectionItemsByTypeProperty(type, propertyName);
+	}
+
+	private class OfCollectionItemsByNodePath implements ComparisonConfigurer.OfCollectionItems
+	{
+		private final NodePath nodePath;
+
+		public OfCollectionItemsByNodePath(final NodePath nodePath)
+		{
+			this.nodePath = nodePath;
+		}
+
+		public ComparisonConfigurer toUse(final IdentityStrategy identityStrategy)
+		{
+			nodePathIdentityStrategies.getNodeForPath(nodePath).setValue(identityStrategy);
+			return comparisonConfigurer;
+		}
+	}
+
+	private class OfCollectionItemsByTypeProperty implements ComparisonConfigurer.OfCollectionItems
+	{
+		private final Class<?> type;
+		private final String propertyName;
+
+		public OfCollectionItemsByTypeProperty(final Class<?> type, final String propertyName)
+		{
+			this.type = type;
+			this.propertyName = propertyName;
+		}
+
+		public ComparisonConfigurer toUse(final IdentityStrategy identityStrategy)
+		{
+			typePropertyIdentityStrategyResolver.setStrategy(identityStrategy, type, propertyName);
+			return comparisonConfigurer;
+		}
+	}
+}

--- a/src/main/java/de/danielbechler/diff/comparison/ComparisonConfigurer.java
+++ b/src/main/java/de/danielbechler/diff/comparison/ComparisonConfigurer.java
@@ -35,9 +35,19 @@ public interface ComparisonConfigurer
 
 	OfPrimitiveTypes ofPrimitiveTypes();
 
+	/**
+	 * Allows to configure the way object identities are established between collection items.
+	 */
+	OfCollectionItems ofCollectionItems(NodePath nodePath);
+
+	/**
+	 * Allows to configure the way object identities are established between collection items.
+	 */
+	OfCollectionItems ofCollectionItems(Class<?> type, String propertyName);
+
 	ObjectDifferBuilder and();
 
-	public interface Of
+	interface Of
 	{
 		ComparisonConfigurer toUse(ComparisonStrategy comparisonStrategy);
 
@@ -48,7 +58,12 @@ public interface ComparisonConfigurer
 		ComparisonConfigurer toUseCompareToMethod();
 	}
 
-	public interface OfPrimitiveTypes
+	interface OfCollectionItems
+	{
+		ComparisonConfigurer toUse(IdentityStrategy identityStrategy);
+	}
+
+	interface OfPrimitiveTypes
 	{
 		ComparisonConfigurer toTreatDefaultValuesAs(PrimitiveDefaultValueMode primitiveDefaultValueMode);
 	}

--- a/src/main/java/de/danielbechler/diff/comparison/ComparisonService.java
+++ b/src/main/java/de/danielbechler/diff/comparison/ComparisonService.java
@@ -27,12 +27,13 @@ import de.danielbechler.util.Classes;
 import java.util.HashMap;
 import java.util.Map;
 
-public class ComparisonService implements ComparisonConfigurer, ComparisonStrategyResolver, PrimitiveDefaultValueModeResolver
+public class ComparisonService implements ComparisonConfigurer, ComparisonStrategyResolver, PrimitiveDefaultValueModeResolver, IdentityStrategyResolver
 {
 	private static final ComparisonStrategy COMPARABLE_COMPARISON_STRATEGY = new ComparableComparisonStrategy();
 	private static final ComparisonStrategy EQUALS_ONLY_COMPARISON_STRATEGY = new EqualsOnlyComparisonStrategy();
 
 	private final NodePathValueHolder<ComparisonStrategy> nodePathComparisonStrategies = NodePathValueHolder.of(ComparisonStrategy.class);
+	private final CollectionComparisonService collectionComparisonService = new CollectionComparisonService(this);
 	private final Map<Class<?>, ComparisonStrategy> typeComparisonStrategyMap = new HashMap<Class<?>, ComparisonStrategy>();
 	private final ObjectDifferBuilder objectDifferBuilder;
 
@@ -113,9 +114,24 @@ public class ComparisonService implements ComparisonConfigurer, ComparisonStrate
 		return new OfPrimitiveTypesImpl();
 	}
 
+	public OfCollectionItems ofCollectionItems(final NodePath nodePath)
+	{
+		return collectionComparisonService.ofCollectionItems(nodePath);
+	}
+
+	public OfCollectionItems ofCollectionItems(final Class<?> type, final String propertyName)
+	{
+		return collectionComparisonService.ofCollectionItems(type, propertyName);
+	}
+
 	public ObjectDifferBuilder and()
 	{
 		return objectDifferBuilder;
+	}
+
+	public IdentityStrategy resolveIdentityStrategy(final DiffNode node)
+	{
+		return collectionComparisonService.resolveIdentityStrategy(node);
 	}
 
 	private abstract static class AbstractOf implements Of
@@ -173,7 +189,7 @@ public class ComparisonService implements ComparisonConfigurer, ComparisonStrate
 		public ComparisonConfigurer toTreatDefaultValuesAs(final PrimitiveDefaultValueMode mode)
 		{
 			primitiveDefaultValueMode = mode;
-			return null;
+			return ComparisonService.this;
 		}
 	}
 }

--- a/src/main/java/de/danielbechler/diff/comparison/EqualsIdentityStrategy.java
+++ b/src/main/java/de/danielbechler/diff/comparison/EqualsIdentityStrategy.java
@@ -1,0 +1,21 @@
+package de.danielbechler.diff.comparison;
+
+import de.danielbechler.util.Objects;
+
+/**
+ * Default implementation that uses Object.equals.
+ */
+public class EqualsIdentityStrategy implements IdentityStrategy
+{
+	private static final EqualsIdentityStrategy instance = new EqualsIdentityStrategy();
+
+	public boolean equals(final Object working, final Object base)
+	{
+		return Objects.isEqual(working, base);
+	}
+
+	public static EqualsIdentityStrategy getInstance()
+	{
+		return instance;
+	}
+}

--- a/src/main/java/de/danielbechler/diff/comparison/IdentityStrategy.java
+++ b/src/main/java/de/danielbechler/diff/comparison/IdentityStrategy.java
@@ -1,0 +1,18 @@
+package de.danielbechler.diff.comparison;
+
+/**
+ * Allows to configure the way objects identities are established when comparing
+ * collections by CollectionDiffer.
+ */
+public interface IdentityStrategy
+{
+
+	/**
+	 * @param working never null
+	 * @param base
+	 * @return
+	 */
+	// TODO Idea: change name to a less overloaded term
+	boolean equals(Object working, Object base);
+
+}

--- a/src/main/java/de/danielbechler/diff/comparison/IdentityStrategyResolver.java
+++ b/src/main/java/de/danielbechler/diff/comparison/IdentityStrategyResolver.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014 Daniel Bechler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.danielbechler.diff.comparison;
+
+import de.danielbechler.diff.node.DiffNode;
+
+public interface IdentityStrategyResolver
+{
+	IdentityStrategy resolveIdentityStrategy(DiffNode node);
+}

--- a/src/main/java/de/danielbechler/diff/comparison/TypePropertyIdentityStrategyResolver.java
+++ b/src/main/java/de/danielbechler/diff/comparison/TypePropertyIdentityStrategyResolver.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2014 Daniel Bechler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.danielbechler.diff.comparison;
+
+import de.danielbechler.diff.node.DiffNode;
+import de.danielbechler.util.Assert;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TypePropertyIdentityStrategyResolver
+{
+	private final Map<PropertyId, IdentityStrategy> strategies = new HashMap<PropertyId, IdentityStrategy>();
+
+	public IdentityStrategy resolve(final DiffNode node)
+	{
+		if (isQualified(node))
+		{
+			final PropertyId propertyKey = new PropertyId(node.getParentNode().getValueType(), node.getPropertyName());
+			return strategies.get(propertyKey);
+		}
+		return null;
+	}
+
+	private static boolean isQualified(final DiffNode node)
+	{
+		if (node.isPropertyAware())
+		{
+			if (node.getParentNode() == null || node.getParentNode().getValueType() == null)
+			{
+				return false;
+			}
+			if (node.getPropertyName() == null)
+			{
+				return false;
+			}
+			return true;
+		}
+		return false;
+	}
+
+	public void setStrategy(final IdentityStrategy identityStrategy, final Class<?> type, final String... properties)
+	{
+		for (final String property : properties)
+		{
+			strategies.put(new PropertyId(type, property), identityStrategy);
+		}
+	}
+
+	private static class PropertyId
+	{
+		private final Class<?> type;
+		private final String property;
+
+		private PropertyId(final Class<?> type, final String property)
+		{
+			Assert.notNull(type, "type");
+			Assert.notNull(property, "property");
+			this.type = type;
+			this.property = property;
+		}
+
+		@Override
+		public int hashCode()
+		{
+			int result = type.hashCode();
+			result = 31 * result + property.hashCode();
+			return result;
+		}
+
+		@Override
+		public boolean equals(final Object o)
+		{
+			if (this == o)
+			{
+				return true;
+			}
+			if (o == null || getClass() != o.getClass())
+			{
+				return false;
+			}
+
+			final PropertyId that = (PropertyId) o;
+
+			if (!property.equals(that.property))
+			{
+				return false;
+			}
+			if (!type.equals(that.type))
+			{
+				return false;
+			}
+
+			return true;
+		}
+	}
+}

--- a/src/main/java/de/danielbechler/diff/differ/CollectionDiffer.java
+++ b/src/main/java/de/danielbechler/diff/differ/CollectionDiffer.java
@@ -21,12 +21,14 @@ import de.danielbechler.diff.access.CollectionItemAccessor;
 import de.danielbechler.diff.access.Instances;
 import de.danielbechler.diff.comparison.ComparisonStrategy;
 import de.danielbechler.diff.comparison.ComparisonStrategyResolver;
+import de.danielbechler.diff.comparison.IdentityStrategy;
+import de.danielbechler.diff.comparison.IdentityStrategyResolver;
 import de.danielbechler.diff.node.DiffNode;
 import de.danielbechler.util.Assert;
-import de.danielbechler.util.Collections;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedList;
 
 /**
  * Used to find differences between {@link Collection Collections}.
@@ -37,52 +39,20 @@ public final class CollectionDiffer implements Differ
 {
 	private final DifferDispatcher differDispatcher;
 	private final ComparisonStrategyResolver comparisonStrategyResolver;
+	private final IdentityStrategyResolver identityStrategyResolver;
 
 	public CollectionDiffer(final DifferDispatcher differDispatcher,
-							final ComparisonStrategyResolver comparisonStrategyResolver)
+							final ComparisonStrategyResolver comparisonStrategyResolver,
+							final IdentityStrategyResolver identityStrategyResolver)
 	{
 		Assert.notNull(differDispatcher, "differDispatcher");
 		this.differDispatcher = differDispatcher;
 
 		Assert.notNull(comparisonStrategyResolver, "comparisonStrategyResolver");
 		this.comparisonStrategyResolver = comparisonStrategyResolver;
-	}
 
-	private static void compareUsingComparisonStrategy(final DiffNode collectionNode,
-													   final Instances collectionInstances,
-													   final ComparisonStrategy comparisonStrategy)
-	{
-		comparisonStrategy.compare(collectionNode, collectionInstances.getType(), collectionInstances.getWorking(Collection.class), collectionInstances.getBase(Collection.class));
-	}
-
-	private static DiffNode newNode(final DiffNode parentNode, final Instances collectionInstances)
-	{
-		final Accessor accessor = collectionInstances.getSourceAccessor();
-		final Class<?> type = collectionInstances.getType();
-		return new DiffNode(parentNode, accessor, type);
-	}
-
-	private static Collection<?> addedItemsOf(final Instances instances)
-	{
-		final Collection<?> working = instances.getWorking(Collection.class);
-		final Collection<?> base = instances.getBase(Collection.class);
-		return Collections.filteredCopyOf(working, base);
-	}
-
-	private static Collection<?> removedItemsOf(final Instances instances)
-	{
-		final Collection<?> working = instances.getWorking(Collection.class);
-		final Collection<?> base = instances.getBase(Collection.class);
-		return Collections.filteredCopyOf(base, working);
-	}
-
-	private static Iterable<?> knownItemsOf(final Instances instances)
-	{
-		final Collection<?> working = instances.getWorking(Collection.class);
-		final Collection<Object> changed = new ArrayList<Object>(working);
-		changed.removeAll(addedItemsOf(instances));
-		changed.removeAll(removedItemsOf(instances));
-		return changed;
+		Assert.notNull(identityStrategyResolver, "identityStrategyResolver");
+		this.identityStrategyResolver = identityStrategyResolver;
 	}
 
 	public boolean accepts(final Class<?> type)
@@ -90,19 +60,21 @@ public final class CollectionDiffer implements Differ
 		return Collection.class.isAssignableFrom(type);
 	}
 
-	public final DiffNode compare(final DiffNode parentNode, final Instances collectionInstances)
+	public final DiffNode compare(final DiffNode parentNode,
+								  final Instances collectionInstances)
 	{
 		final DiffNode collectionNode = newNode(parentNode, collectionInstances);
+		final IdentityStrategy identityStrategy = identityStrategyResolver.resolveIdentityStrategy(collectionNode);
 		if (collectionInstances.hasBeenAdded())
 		{
 			final Collection addedItems = collectionInstances.getWorking(Collection.class);
-			compareItems(collectionNode, collectionInstances, addedItems);
+			compareItems(collectionNode, collectionInstances, addedItems, identityStrategy);
 			collectionNode.setState(DiffNode.State.ADDED);
 		}
 		else if (collectionInstances.hasBeenRemoved())
 		{
 			final Collection<?> removedItems = collectionInstances.getBase(Collection.class);
-			compareItems(collectionNode, collectionInstances, removedItems);
+			compareItems(collectionNode, collectionInstances, removedItems, identityStrategy);
 			collectionNode.setState(DiffNode.State.REMOVED);
 		}
 		else if (collectionInstances.areSame())
@@ -114,7 +86,7 @@ public final class CollectionDiffer implements Differ
 			final ComparisonStrategy comparisonStrategy = comparisonStrategyResolver.resolveComparisonStrategy(collectionNode);
 			if (comparisonStrategy == null)
 			{
-				compareInternally(collectionNode, collectionInstances);
+				compareInternally(collectionNode, collectionInstances, identityStrategy);
 			}
 			else
 			{
@@ -124,21 +96,82 @@ public final class CollectionDiffer implements Differ
 		return collectionNode;
 	}
 
-	private void compareInternally(final DiffNode collectionNode, final Instances collectionInstances)
+	private static DiffNode newNode(final DiffNode parentNode,
+									final Instances collectionInstances)
 	{
-		compareItems(collectionNode, collectionInstances, addedItemsOf(collectionInstances));
-		compareItems(collectionNode, collectionInstances, removedItemsOf(collectionInstances));
-		compareItems(collectionNode, collectionInstances, knownItemsOf(collectionInstances));
+		final Accessor accessor = collectionInstances.getSourceAccessor();
+		final Class<?> type = collectionInstances.getType();
+		return new DiffNode(parentNode, accessor, type);
 	}
 
 	private void compareItems(final DiffNode collectionNode,
 							  final Instances collectionInstances,
-							  final Iterable<?> items)
+							  final Iterable<?> items,
+							  final IdentityStrategy identityStrategy)
 	{
 		for (final Object item : items)
 		{
-			final Accessor itemAccessor = new CollectionItemAccessor(item);
+			final Accessor itemAccessor = new CollectionItemAccessor(item, identityStrategy);
 			differDispatcher.dispatch(collectionNode, collectionInstances, itemAccessor);
 		}
+	}
+
+	private void compareInternally(final DiffNode collectionNode,
+								   final Instances collectionInstances,
+								   final IdentityStrategy identityStrategy)
+	{
+		final Collection<?> working = collectionInstances.getWorking(Collection.class);
+		final Collection<?> base = collectionInstances.getBase(Collection.class);
+
+		final Collection<?> added = new LinkedList<Object>(working);
+		final Collection<?> removed = new LinkedList<Object>(base);
+		final Collection<?> known = new LinkedList<Object>(base);
+
+		remove(added, base, identityStrategy);
+		remove(removed, working, identityStrategy);
+		remove(known, added, identityStrategy);
+		remove(known, removed, identityStrategy);
+
+		// TODO I am not sure why these are separate exactly? (NagyGa1)
+		// TODO Neither am I... (SQiShER)
+		// TODO cool (NagyGa1)
+		compareItems(collectionNode, collectionInstances, added, identityStrategy);
+		compareItems(collectionNode, collectionInstances, removed, identityStrategy);
+		compareItems(collectionNode, collectionInstances, known, identityStrategy);
+	}
+
+	private static void compareUsingComparisonStrategy(
+			final DiffNode collectionNode, final Instances collectionInstances,
+			final ComparisonStrategy comparisonStrategy)
+	{
+		comparisonStrategy.compare(collectionNode,
+				collectionInstances.getType(),
+				collectionInstances.getWorking(Collection.class),
+				collectionInstances.getBase(Collection.class));
+	}
+
+	private void remove(final Iterable<?> from, final Iterable<?> these, final IdentityStrategy identityStrategy)
+	{
+		final Iterator<?> iterator = from.iterator();
+		while (iterator.hasNext())
+		{
+			final Object item = iterator.next();
+			if (contains(these, item, identityStrategy))
+			{
+				iterator.remove();
+			}
+		}
+	}
+
+	private boolean contains(final Iterable<?> haystack, final Object needle, final IdentityStrategy identityStrategy)
+	{
+		for (final Object item : haystack)
+		{
+			if (identityStrategy.equals(needle, item))
+			{
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/src/main/java/de/danielbechler/diff/selector/CollectionItemElementSelector.java
+++ b/src/main/java/de/danielbechler/diff/selector/CollectionItemElementSelector.java
@@ -16,6 +16,9 @@
 
 package de.danielbechler.diff.selector;
 
+import de.danielbechler.diff.comparison.EqualsIdentityStrategy;
+import de.danielbechler.diff.comparison.IdentityStrategy;
+import de.danielbechler.util.Assert;
 import de.danielbechler.util.Strings;
 
 /**
@@ -24,14 +27,36 @@ import de.danielbechler.util.Strings;
 public final class CollectionItemElementSelector extends ElementSelector
 {
 	private final Object item;
+	private final IdentityStrategy identityStrategy;
 
+	/**
+	 * Default implementation uses IdentityService.EQUALS_IDENTITY_STRATEGY.
+	 *
+	 * @param item
+	 */
 	public CollectionItemElementSelector(final Object item)
 	{
 		this.item = item;
+		this.identityStrategy = EqualsIdentityStrategy.getInstance();
 	}
 
 	/**
-	 * @deprecated Low-level API. Don't use in production code. May be removed in future versions.
+	 * Allows for custom IdentityStrategy.
+	 *
+	 * @param item
+	 * @param identityStrategy
+	 */
+	public CollectionItemElementSelector(final Object item,
+										 final IdentityStrategy identityStrategy)
+	{
+		this.item = item;
+		Assert.notNull(identityStrategy, "identityStrategy");
+		this.identityStrategy = identityStrategy;
+	}
+
+	/**
+	 * @deprecated Low-level API. Don't use in production code. May be removed
+	 * in future versions.
 	 */
 	@SuppressWarnings({"UnusedDeclaration"})
 	@Deprecated
@@ -60,7 +85,9 @@ public final class CollectionItemElementSelector extends ElementSelector
 
 		final CollectionItemElementSelector that = (CollectionItemElementSelector) o;
 
-		if (item != null ? !item.equals(that.item) : that.item != null)
+		if (item != null
+				? !identityStrategy.equals(item, that.item)
+				: that.item != null)
 		{
 			return false;
 		}


### PR DESCRIPTION
Okay, this is just a draft, not a serious pull request.
Issues:
 * I am not at all sure if this fits to the big picture and works. E.g. now accessors created by CollectionDiffer do contain the reference to the custom IdentityStrategy, but everything else is defaulted to EqualsStrategy. (It might work, but one source of confusion, have a look at `IdentityStrategyIT#'Test field CODE equals equals CHANGED'()`, CollectionItemElementSelectors created there need to be explicitly told about the strategy. Maybe could be stored at the node? But the accessor / selector does not seem to have access to that.
 * Configuration should be different I guess. The by class method is not the best as `ArrayList` can be a lot of other places in the graph. The Path did not match when I tried as `Node.with("/")`, tried to match it to "//".
 * If it happens to work I will fix formatting issues (e.g. {}'s) later.