### PR TITLE
use dummy introspector if java.beans.Introspector is not available

### DIFF
--- a/src/main/java/de/danielbechler/diff/introspection/DummyIntrospector.java
+++ b/src/main/java/de/danielbechler/diff/introspection/DummyIntrospector.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 Daniel Bechler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.danielbechler.diff.introspection;
+
+import de.danielbechler.diff.instantiation.TypeInfo;
+import de.danielbechler.util.Assert;
+
+/**
+ * Does not attempt to resolve any accessor of the given type.
+ *
+ * @author Pascal Brogle
+ */
+public class DummyIntrospector implements de.danielbechler.diff.introspection.Introspector
+{
+	public TypeInfo introspect(final Class<?> type)
+	{
+		Assert.notNull(type, "type");
+		return new TypeInfo(type);
+	}
+}

--- a/src/main/java/de/danielbechler/diff/introspection/IntrospectionService.java
+++ b/src/main/java/de/danielbechler/diff/introspection/IntrospectionService.java
@@ -39,13 +39,22 @@ public class IntrospectionService implements IntrospectionConfigurer, IsIntrospe
 	private final NodePathValueHolder<Introspector> nodePathIntrospectorHolder = new NodePathValueHolder<Introspector>();
 	private final NodePathValueHolder<IntrospectionMode> nodePathIntrospectionModeHolder = new NodePathValueHolder<IntrospectionMode>();
 	private final ObjectDifferBuilder objectDifferBuilder;
-	private Introspector defaultIntrospector = new StandardIntrospector();
+	private Introspector defaultIntrospector;
 	private InstanceFactory instanceFactory = new PublicNoArgsConstructorInstanceFactory();
 	private PropertyAccessExceptionHandler defaultPropertyAccessExceptionHandler = new DefaultPropertyAccessExceptionHandler();
 
 	public IntrospectionService(final ObjectDifferBuilder objectDifferBuilder)
 	{
 		this.objectDifferBuilder = objectDifferBuilder;
+		try
+		{
+			Class.forName("java.beans.Introspector");
+			defaultIntrospector = new StandardIntrospector();
+		}
+		catch(final ClassNotFoundException e )
+		{
+			defaultIntrospector = new DummyIntrospector();
+		}
 	}
 
 	public boolean isIntrospectable(final DiffNode node)


### PR DESCRIPTION
This fix is related to #147. We ran into issue with using java-object-diff on android.

We are using our own custom introspector, and this seems to work fine as long as we don't enable proguard optimizations. Even though we don't use the `StandardIntrospector`, it is initialized as part of the `IntrospectionService` initalization and the proguard optimization together with the lack of java.beans on android produce an `java.lang.VerifyError`.

It is not the cleanest solution, but works for us.