### PR TITLE
lazy initalize default introspector

### DIFF
--- a/src/main/java/de/danielbechler/diff/introspection/IntrospectionService.java
+++ b/src/main/java/de/danielbechler/diff/introspection/IntrospectionService.java
@@ -39,7 +39,7 @@ public class IntrospectionService implements IntrospectionConfigurer, IsIntrospe
 	private final NodePathValueHolder<Introspector> nodePathIntrospectorHolder = new NodePathValueHolder<Introspector>();
 	private final NodePathValueHolder<IntrospectionMode> nodePathIntrospectionModeHolder = new NodePathValueHolder<IntrospectionMode>();
 	private final ObjectDifferBuilder objectDifferBuilder;
-	private Introspector defaultIntrospector = new StandardIntrospector();
+	private Introspector defaultIntrospector;
 	private InstanceFactory instanceFactory = new PublicNoArgsConstructorInstanceFactory();
 	private PropertyAccessExceptionHandler defaultPropertyAccessExceptionHandler = new DefaultPropertyAccessExceptionHandler();
 
@@ -106,6 +106,10 @@ public class IntrospectionService implements IntrospectionConfigurer, IsIntrospe
 			return nodePathIntrospector;
 		}
 
+		if (defaultIntrospector == null)
+		{
+			defaultIntrospector = new StandardIntrospector();
+		}
 		return defaultIntrospector;
 	}
 


### PR DESCRIPTION
replaces / closes #156.

lazy initialisation of the standard inspector ensure that on android the `java.beans.Introspector` class is never tried to be loaded when using a custom introspector