### PR TITLE
Return Object.class from Instances#getType instead of throwing an exc…

### DIFF
--- a/src/integration-test/java/de/danielbechler/diff/ObjectDifferIT.groovy
+++ b/src/integration-test/java/de/danielbechler/diff/ObjectDifferIT.groovy
@@ -229,10 +229,8 @@ public class ObjectDifferIT extends Specification {
 	}
 
 	def 'compare with different types'() {
-		when:
-		  ObjectDifferBuilder.buildDefault().compare('foo', 1337)
-		then:
-		  thrown IllegalArgumentException
+		expect:
+		  ObjectDifferBuilder.buildDefault().compare('foo', 1337).changed
 	}
 
 	def 'compare with ignored property'() {

--- a/src/main/java/de/danielbechler/diff/access/Instances.java
+++ b/src/main/java/de/danielbechler/diff/access/Instances.java
@@ -230,7 +230,7 @@ public class Instances
 		}
 
 		logger.info("Detected instances of different types " + types + ". " +
-								"Instances should normally either be null or have the exact same type.");
+			    "Instances should normally either be null or have the exact same type.");
 		return Object.class;
 	}
 

--- a/src/main/java/de/danielbechler/diff/access/Instances.java
+++ b/src/main/java/de/danielbechler/diff/access/Instances.java
@@ -230,7 +230,7 @@ public class Instances
 		}
 
 		logger.info("Detected instances of different types " + types + ". " +
-			    "Instances should normally either be null or have the exact same type.");
+			    "These objects will only be compared via equals method.");
 		return Object.class;
 	}
 

--- a/src/main/java/de/danielbechler/diff/access/Instances.java
+++ b/src/main/java/de/danielbechler/diff/access/Instances.java
@@ -225,8 +225,7 @@ public class Instances
 				// special handling for beans and arrays should go here
 			}
 		}
-		throw new IllegalArgumentException("Detected instances of different types " + types + ". " +
-				"Instances must either be null or have the exact same type.");
+		return Object.class;
 	}
 
 	private Class<?> tryToGetTypeFromSourceAccessor()

--- a/src/main/java/de/danielbechler/diff/access/Instances.java
+++ b/src/main/java/de/danielbechler/diff/access/Instances.java
@@ -19,6 +19,8 @@ package de.danielbechler.diff.access;
 import de.danielbechler.util.Assert;
 import de.danielbechler.util.Classes;
 import de.danielbechler.util.Collections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Map;
@@ -28,6 +30,7 @@ import static de.danielbechler.util.Objects.isEqual;
 
 public class Instances
 {
+	private static final Logger logger = LoggerFactory.getLogger(Instances.class);
 	private final Accessor sourceAccessor;
 	private final Object working;
 	private final Object base;
@@ -225,6 +228,9 @@ public class Instances
 				// special handling for beans and arrays should go here
 			}
 		}
+
+		logger.info("Detected instances of different types " + types + ". " +
+								"Instances should normally either be null or have the exact same type.");
 		return Object.class;
 	}
 

--- a/src/main/java/de/danielbechler/diff/comparison/ComparisonService.java
+++ b/src/main/java/de/danielbechler/diff/comparison/ComparisonService.java
@@ -90,6 +90,11 @@ public class ComparisonService implements ComparisonConfigurer, ComparisonStrate
 			}
 		}
 
+		if (valueType == Object.class)
+		{
+			return EQUALS_ONLY_COMPARISON_STRATEGY;
+		}
+
 		return null;
 	}
 

--- a/src/test/java/de/danielbechler/diff/access/InstancesTest.groovy
+++ b/src/test/java/de/danielbechler/diff/access/InstancesTest.groovy
@@ -21,15 +21,12 @@ import spock.lang.Unroll
 
 class InstancesTest extends Specification {
 
-	def "getType: throws IllegalArgumentException if base and working have incompatible types"() {
+	def "getType: returns Object.class if base and working have different types"() {
 		setup:
 		  def instances = new Instances(RootAccessor.instance, working, base, null)
 
-		when:
-		  instances.getType()
-
-		then:
-		  thrown(IllegalArgumentException)
+		expect:
+		  instances.getType() == Object.class
 
 		where:
 		  base                | working


### PR DESCRIPTION
…eption when instances have different types. Fall back to EqualsOnlyComparisonStrategy in this case.