### PR TITLE
Primitives gets wrong status

### DIFF
--- a/src/test/java/de/danielbechler/diff/mock/ObjectWithCollectionOfComplexTypes.java
+++ b/src/test/java/de/danielbechler/diff/mock/ObjectWithCollectionOfComplexTypes.java
@@ -1,0 +1,13 @@
+package de.danielbechler.diff.mock;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ObjectWithCollectionOfComplexTypes {
+	
+	private List<ObjectWithPrimitivePropertyAndHashCodeAndEquals> list = new ArrayList<ObjectWithPrimitivePropertyAndHashCodeAndEquals>();
+
+	public List<ObjectWithPrimitivePropertyAndHashCodeAndEquals> getList() {
+		return list;
+	}
+}

--- a/src/test/java/de/danielbechler/diff/mock/ObjectWithPrimitivePropertyAndHashCodeAndEquals.java
+++ b/src/test/java/de/danielbechler/diff/mock/ObjectWithPrimitivePropertyAndHashCodeAndEquals.java
@@ -1,0 +1,38 @@
+package de.danielbechler.diff.mock;
+
+public class ObjectWithPrimitivePropertyAndHashCodeAndEquals {
+	
+	private int primitive;
+
+	public int getPrimitive() {
+		return primitive;
+	}
+
+	public void setPrimitive(int primitive) {
+		this.primitive = primitive;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + primitive;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		ObjectWithPrimitivePropertyAndHashCodeAndEquals other = (ObjectWithPrimitivePropertyAndHashCodeAndEquals) obj;
+		if (primitive != other.primitive)
+			return false;
+		return true;
+	}
+	
+	
+}


### PR DESCRIPTION
Thank you for this library.
Diffing a list with a object implementing equals and have a primitive value makes the REMOVED primitive get a status of ADDED.

Output from a PrintingVisitor is
```
Property at path '/wrapper[fcmp.diff.DifferTest$TestClass@1f]/primitive' has been added => [ null ]
```
Which should have been:
```
Property at path '/wrapper[fcmp.diff.DifferTest$TestClass@1f]/primitive' has been removed => [ 0 ]
```