### PR TITLE
Introspector that can deal with public fields

### DIFF
--- a/src/main/java/de/danielbechler/diff/introspection/DefaultIntrospector.java
+++ b/src/main/java/de/danielbechler/diff/introspection/DefaultIntrospector.java
@@ -1,0 +1,42 @@
+package de.danielbechler.diff.introspection;
+
+import de.danielbechler.diff.access.PropertyAwareAccessor;
+import de.danielbechler.diff.instantiation.TypeInfo;
+
+import java.util.Collection;
+
+public class DefaultIntrospector implements Introspector
+{
+	private final FieldIntrospector fieldIntrospector = new FieldIntrospector();
+	private final GetterSetterIntrospector getterSetterIntrospector = new GetterSetterIntrospector();
+	private boolean returnFields = false;
+
+	public TypeInfo introspect(final Class<?> type)
+	{
+		final TypeInfo typeInfo = new TypeInfo(type);
+		if (returnFields)
+		{
+			final Collection<PropertyAwareAccessor> fieldAccessors = fieldIntrospector.introspect(type).getAccessors();
+			for (final PropertyAwareAccessor fieldAccessor : fieldAccessors)
+			{
+				typeInfo.addPropertyAccessor(fieldAccessor);
+			}
+		}
+		final Collection<PropertyAwareAccessor> getterSetterAccessors = getterSetterIntrospector.introspect(type).getAccessors();
+		for (final PropertyAwareAccessor getterSetterAccessor : getterSetterAccessors)
+		{
+			typeInfo.addPropertyAccessor(getterSetterAccessor);
+		}
+		return typeInfo;
+	}
+
+	public void setReturnFields(final boolean returnFields)
+	{
+		this.returnFields = returnFields;
+	}
+
+	public void setReturnFinalFields(final boolean returnFinalFields)
+	{
+		fieldIntrospector.setReturnFinalFields(returnFinalFields);
+	}
+}

--- a/src/main/java/de/danielbechler/diff/introspection/FieldAccessor.java
+++ b/src/main/java/de/danielbechler/diff/introspection/FieldAccessor.java
@@ -1,0 +1,105 @@
+package de.danielbechler.diff.introspection;
+
+import de.danielbechler.diff.access.PropertyAwareAccessor;
+import de.danielbechler.diff.selector.BeanPropertyElementSelector;
+import de.danielbechler.diff.selector.ElementSelector;
+import de.danielbechler.util.Assert;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class FieldAccessor implements PropertyAwareAccessor
+{
+	private final Field field;
+
+	FieldAccessor(final Field field)
+	{
+		Assert.notNull(field, "field");
+		this.field = field;
+	}
+
+	public Class<?> getType()
+	{
+		return field.getType();
+	}
+
+	public Set<String> getCategoriesFromAnnotation()
+	{
+		return Collections.emptySet();
+	}
+
+	public ElementSelector getElementSelector()
+	{
+		return new BeanPropertyElementSelector(getPropertyName());
+	}
+
+	public Object get(Object target)
+	{
+		try
+		{
+			return field.get(target);
+		}
+		catch (IllegalAccessException e)
+		{
+			throw new PropertyReadException(getPropertyName(), getType(), e);
+		}
+	}
+
+	public void set(Object target, Object value)
+	{
+		try
+		{
+			field.setAccessible(true);
+			field.set(target, value);
+		}
+		catch (IllegalAccessException e)
+		{
+			throw new PropertyWriteException(getPropertyName(), getType(), value, e);
+		}
+		finally
+		{
+			field.setAccessible(false);
+		}
+	}
+
+	public void unset(Object target)
+	{
+	}
+
+	public String getPropertyName()
+	{
+		return field.getName();
+	}
+
+	public Set<Annotation> getFieldAnnotations()
+	{
+		final Set<Annotation> fieldAnnotations = new HashSet<Annotation>(field.getAnnotations().length);
+		fieldAnnotations.addAll(Arrays.asList(field.getAnnotations()));
+		return fieldAnnotations;
+	}
+
+	public <T extends Annotation> T getFieldAnnotation(Class<T> annotationClass)
+	{
+		return field.getAnnotation(annotationClass);
+	}
+
+	public Set<Annotation> getReadMethodAnnotations()
+	{
+		return Collections.emptySet();
+	}
+
+	public <T extends Annotation> T getReadMethodAnnotation(Class<T> annotationClass)
+	{
+		return null;
+	}
+
+	public boolean isExcludedByAnnotation()
+	{
+		ObjectDiffProperty annotation = getFieldAnnotation(ObjectDiffProperty.class);
+		return annotation != null && annotation.excluded();
+	}
+}

--- a/src/main/java/de/danielbechler/diff/introspection/FieldIntrospector.java
+++ b/src/main/java/de/danielbechler/diff/introspection/FieldIntrospector.java
@@ -1,0 +1,34 @@
+package de.danielbechler.diff.introspection;
+
+import de.danielbechler.diff.instantiation.TypeInfo;
+
+import java.lang.reflect.*;
+
+public class FieldIntrospector implements Introspector
+{
+    private boolean returnFinalFields;
+
+    public TypeInfo introspect(final Class<?> type)
+    {
+        final TypeInfo typeInfo = new TypeInfo(type);
+        for (final Field field : type.getFields())
+        {
+            if (shouldSkip(field))
+            {
+                continue;
+            }
+            typeInfo.addPropertyAccessor(new FieldAccessor(field));
+        }
+        return typeInfo;
+    }
+
+    private boolean shouldSkip(final Field field)
+    {
+        return Modifier.isFinal(field.getModifiers()) && !returnFinalFields;
+    }
+
+    public void setReturnFinalFields(final boolean returnFinalFields)
+    {
+        this.returnFinalFields = returnFinalFields;
+    }
+}

--- a/src/main/java/de/danielbechler/diff/introspection/GetterSetterIntrospector.java
+++ b/src/main/java/de/danielbechler/diff/introspection/GetterSetterIntrospector.java
@@ -1,0 +1,81 @@
+package de.danielbechler.diff.introspection;
+
+import de.danielbechler.diff.instantiation.TypeInfo;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GetterSetterIntrospector implements Introspector
+{
+	public TypeInfo introspect(final Class<?> type)
+	{
+		final TypeInfo typeInfo = new TypeInfo(type);
+		for (final Method getter : gettersOf(type))
+		{
+			if (shouldSkip(getter))
+			{
+				continue;
+			}
+			final String propertyName = getPropertyName(getter);
+			final Method setter = getCorrespondingSetter(type, getter);
+			final PropertyAccessor accessor = new PropertyAccessor(propertyName, getter, setter);
+			typeInfo.addPropertyAccessor(accessor);
+		}
+		return typeInfo;
+	}
+
+	private Method getCorrespondingSetter(final Class<?> type, final Method getter)
+	{
+		final String setterMethodName = getter.getName().replaceAll("^get", "set");
+		try
+		{
+			return type.getMethod(setterMethodName, getter.getReturnType());
+		}
+		catch (NoSuchMethodException ignored)
+		{
+			return null;
+		}
+	}
+
+	private String getPropertyName(final Method getter)
+	{
+		final StringBuilder sb = new StringBuilder(getter.getName());
+		sb.delete(0, 3);
+		sb.setCharAt(0, Character.toLowerCase(sb.charAt(0)));
+		return sb.toString();
+	}
+
+	private List<Method> gettersOf(final Class<?> type)
+	{
+		final List<Method> filteredMethods = new ArrayList<Method>(type.getMethods().length);
+		for (final Method method : type.getMethods())
+		{
+			final String methodName = method.getName();
+			if (!methodName.startsWith("get") || methodName.length() <= 3)
+			{
+				continue;
+			}
+			if (method.getGenericParameterTypes().length != 0)
+			{
+				continue;
+			}
+			filteredMethods.add(method);
+		}
+		return filteredMethods;
+	}
+
+	@SuppressWarnings("RedundantIfStatement")
+	private static boolean shouldSkip(final Method getter)
+	{
+		if (getter.getName().equals("getClass")) // Java & Groovy
+		{
+			return true;
+		}
+		if (getter.getName().equals("getMetaClass")) // Groovy
+		{
+			return true;
+		}
+		return false;
+	}
+}

--- a/src/main/java/de/danielbechler/diff/introspection/ObjectDiffProperty.java
+++ b/src/main/java/de/danielbechler/diff/introspection/ObjectDiffProperty.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  * @author Daniel Bechler
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.FIELD})
 @Inherited
 public @interface ObjectDiffProperty
 {

--- a/src/test/java/de/danielbechler/diff/introspection/DtoForTesting.java
+++ b/src/test/java/de/danielbechler/diff/introspection/DtoForTesting.java
@@ -1,0 +1,14 @@
+package de.danielbechler.diff.introspection;
+
+@SuppressWarnings("WeakerAccess")
+public class DtoForTesting
+{
+	@ObjectDiffProperty(categories = {"foo"}, excluded = true)
+	public String publicField;
+	public final String publicFinalField;
+
+	public DtoForTesting(String publicFinalField)
+	{
+		this.publicFinalField = publicFinalField;
+	}
+}

--- a/src/test/java/de/danielbechler/diff/introspection/FieldAccessorTest.groovy
+++ b/src/test/java/de/danielbechler/diff/introspection/FieldAccessorTest.groovy
@@ -1,0 +1,91 @@
+package de.danielbechler.diff.introspection
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.lang.annotation.Annotation
+import java.lang.reflect.Field
+
+class FieldAccessorTest extends Specification {
+
+	@Subject
+	FieldAccessor fieldAccessor
+
+	def setup() {
+		Field field = DtoForTesting.class.fields.find { Field field -> field.name == 'publicField' }
+		fieldAccessor = new FieldAccessor(field)
+	}
+
+	def 'getPropertyName'() {
+		expect:
+		fieldAccessor.propertyName == 'publicField'
+	}
+
+	def 'getType'() {
+		expect:
+		fieldAccessor.type == String
+	}
+
+	def 'get'() {
+		setup:
+		String expectedValue = UUID.randomUUID().toString()
+		DtoForTesting dto = new DtoForTesting('foo')
+		dto.publicField = expectedValue
+		expect:
+		fieldAccessor.get(dto) == expectedValue
+	}
+
+	def 'set'() {
+		given:
+		DtoForTesting dto = new DtoForTesting('foo')
+		when:
+		String expectedValue = UUID.randomUUID().toString()
+		fieldAccessor.set(dto, expectedValue)
+		then:
+		dto.publicField == expectedValue
+	}
+
+	def 'set should be able to change value of static field'() {
+		given:
+		fieldAccessor = new FieldAccessor(DtoForTesting.class.fields.find { Field field ->
+			field.name == 'publicFinalField'
+		})
+		DtoForTesting dto = new DtoForTesting('foo')
+		when:
+		fieldAccessor.set(dto, 'bar')
+		then:
+		dto.publicFinalField == 'bar'
+	}
+
+	def 'getFieldAnnotations'() {
+		when:
+		Set<Annotation> annotations = fieldAccessor.fieldAnnotations
+		then:
+		annotations.size() == 1
+		and:
+		ObjectDiffProperty annotation = annotations.first() as ObjectDiffProperty
+		annotation.categories() as List == ['foo']
+	}
+
+	def 'getFieldAnnotation'() {
+		setup:
+		def annotation = fieldAccessor.getFieldAnnotation(ObjectDiffProperty)
+		expect:
+		annotation != null
+	}
+
+	def 'getReadMethodAnnotations'() {
+		expect:
+		fieldAccessor.readMethodAnnotations == [] as Set
+	}
+
+	def 'getReadMethodAnnotation'() {
+		expect:
+		fieldAccessor.getReadMethodAnnotation(ObjectDiffProperty) == null
+	}
+
+	def 'isExcludedByAnnotation'() {
+		expect:
+		fieldAccessor.isExcludedByAnnotation()
+	}
+}

--- a/src/test/java/de/danielbechler/diff/introspection/FieldIntrospectorTest.groovy
+++ b/src/test/java/de/danielbechler/diff/introspection/FieldIntrospectorTest.groovy
@@ -1,0 +1,38 @@
+package de.danielbechler.diff.introspection
+
+import de.danielbechler.diff.access.PropertyAwareAccessor
+import de.danielbechler.diff.instantiation.TypeInfo
+import spock.lang.Specification
+
+class FieldIntrospectorTest extends Specification {
+
+	FieldIntrospector introspector = new FieldIntrospector()
+
+	def 'should not return accessors for final fields if deactivated'() {
+		given:
+		introspector.setReturnFinalFields(false)
+		when:
+		TypeInfo result = introspector.introspect(DtoForTesting.class)
+		then:
+		result.accessors.find { PropertyAwareAccessor accessor -> accessor.propertyName == 'publicFinalField' } == null
+		result.accessors.find { PropertyAwareAccessor accessor -> accessor.propertyName == 'publicField' } != null
+	}
+
+	def 'should return accessors for final fields if activated'() {
+		given:
+		introspector.setReturnFinalFields(true)
+		when:
+		TypeInfo result = introspector.introspect(DtoForTesting.class)
+		then:
+		result.accessors.find { PropertyAwareAccessor accessor -> accessor.propertyName == 'publicFinalField' } != null
+		result.accessors.find { PropertyAwareAccessor accessor -> accessor.propertyName == 'publicField' } != null
+	}
+
+	def 'should returns accessors for public fields'() {
+		when:
+		TypeInfo result = introspector.introspect(DtoForTesting.class)
+		then:
+		result.accessors.size() == 1
+		result.accessors.first().propertyName == 'publicField'
+	}
+}

--- a/src/test/java/de/danielbechler/diff/introspection/GetterSetterIntrospectorTest.groovy
+++ b/src/test/java/de/danielbechler/diff/introspection/GetterSetterIntrospectorTest.groovy
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2014 Daniel Bechler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.danielbechler.diff.introspection
+
+import de.danielbechler.diff.access.PropertyAwareAccessor
+import de.danielbechler.diff.mock.ObjectWithString
+import spock.lang.Specification
+
+import java.beans.BeanInfo
+import java.beans.IntrospectionException
+
+/**
+ * @author Daniel Bechler
+ */
+public class GetterSetterIntrospectorTest extends Specification {
+
+	def introspector = new GetterSetterIntrospector()
+
+	private Map<String, PropertyAwareAccessor> introspect(Class<?> type) {
+		introspector.introspect(type).accessors.collectEntries {
+			accessor -> [accessor.propertyName, accessor]
+		}
+	}
+
+	def 'should return proper accessor for property'() {
+		when:
+		def accessor = introspect(TypeWithOnlyOneProperty).get('value')
+		then:
+		accessor.propertyName == 'value'
+		and:
+		def target = new TypeWithOnlyOneProperty()
+		accessor.get(target) == null
+		and:
+		accessor.set(target, 'bar')
+		accessor.get(target) == 'bar'
+		and:
+		accessor.excludedByAnnotation == false
+		and:
+		accessor.categoriesFromAnnotation.isEmpty()
+	}
+
+	def 'should return PropertyAwareAccessors for each property of the given class'() {
+		when:
+		def accessors = introspect(TypeWithTwoProperties)
+		then:
+		accessors.size() == 2
+		accessors.get('foo') != null
+		accessors.get('bar') != null
+	}
+
+	def 'should apply categories of ObjectDiffProperty annotation to accessor'() {
+		when:
+		def accessor = introspect(TypeWithPropertyAnnotation).get('value')
+		then:
+		accessor.categoriesFromAnnotation.size() == 2
+		accessor.categoriesFromAnnotation.containsAll(['category1', 'category2'])
+	}
+
+	def 'should apply exclusion of ObjectDiffProperty annotation to accessor'() {
+		when:
+		def accessor = introspect(TypeWithPropertyAnnotation).get('value')
+		then:
+		accessor.excludedByAnnotation == true
+	}
+
+	def 'should throw exception when invoked without type'() {
+		when:
+		introspector.introspect(null)
+		then:
+		thrown(IllegalArgumentException)
+	}
+
+	def 'should skip default class properties'() {
+		expect:
+		introspect(TypeWithNothingButDefaultProperties).isEmpty()
+	}
+
+	def 'should skip properties without getter'() {
+		expect:
+		introspect(TypeWithPropertyWithoutGetter).isEmpty()
+	}
+
+	def 'should wrap IntrospectionException with RuntimeException'() {
+		given:
+		introspector = new StandardIntrospector() {
+			@Override
+			protected BeanInfo getBeanInfo(final Class<?> type) throws IntrospectionException {
+				throw new IntrospectionException(type.getCanonicalName());
+			}
+		};
+		when:
+		introspector.introspect(ObjectWithString.class);
+		then:
+		thrown(RuntimeException)
+	}
+
+	private class TypeWithNothingButDefaultProperties {
+	}
+
+	private class TypeWithPropertyWithoutGetter {
+		private String value
+
+		void setValue(String value) {
+			this.value = value
+		}
+	}
+
+	private class TypeWithPropertyAnnotation {
+		private String value
+
+		@ObjectDiffProperty(excluded = true, categories = ['category1', 'category2'])
+		String getValue() {
+			return value
+		}
+
+		void setValue(String value) {
+			this.value = value
+		}
+	}
+
+	private class TypeWithOnlyOneProperty {
+		def value
+	}
+
+	private class TypeWithTwoProperties {
+		def foo
+		def bar
+	}
+}

--- a/src/test/java/de/danielbechler/diff/introspection/IntrospectorTestType.java
+++ b/src/test/java/de/danielbechler/diff/introspection/IntrospectorTestType.java
@@ -1,0 +1,32 @@
+package de.danielbechler.diff.introspection;
+
+public class IntrospectorTestType
+{
+	public static final String constantField = "constant_field";
+	private String privateField;
+	String packageProtectedField;
+	protected String protectedField;
+	public String publicField;
+	@ObjectDiffProperty
+	public String annotatedPublicField;
+	public final String publicFinalField = "public_final_field";
+	private String readWriteProperty;
+	@ObjectDiffProperty
+	private String fieldAnnotatedReadOnlyProperty;
+
+	@ObjectDiffProperty
+	public String getReadWriteProperty()
+	{
+		return readWriteProperty;
+	}
+
+	public void setReadWriteProperty(final String readWriteProperty)
+	{
+		this.readWriteProperty = readWriteProperty;
+	}
+
+	public String getFieldAnnotatedReadOnlyProperty()
+	{
+		return fieldAnnotatedReadOnlyProperty;
+	}
+}


### PR DESCRIPTION
This PR adds several new introspectors to support a wider array of use-cases.

The `FieldIntrospector` detects the properties of the underlying classes by scanning the public fields and exposing them as simple accessors.

The `GetterSetterIntropector` is a drop-in replacement for the currently used `StandardIntrospector`. It uses simple reflection instead of the more sophisticated JRE-provided `java.beans.Introspector` at the cost of performance (although as of right now this is just an assumption. I didn't test it). The big advantage of this approach is Android-compatbility, since the `java.beans.Introspector` isn't available on Android-platforms.

The `DefaultIntrospector` is just a composite of the above mentioned two with the option to enable field introspection. Once it's fully tested and I'm sure it behaves exactly like the `StandardIntrospector` it will become the new default and the `StandardIntrospector` will be removed.