### PR TITLE
Fixed Javadoc errors

### DIFF
--- a/src/main/java/de/danielbechler/diff/ObjectDifferBuilder.java
+++ b/src/main/java/de/danielbechler/diff/ObjectDifferBuilder.java
@@ -119,14 +119,14 @@ public class ObjectDifferBuilder
 
 	/**
 	 * <b>EXPERT FEATURE</b>: Allows to configure the way the identity of objects is determined in order to establish
-	 * the relationship between different versions. By default this is done via the <code>equals</code> method; but
+	 * the relationship between different versions. By default, this is done via the <code>equals</code> method; but
 	 * sometimes that's just not possible. For example when you are dealing with generated classes or you are dealing
 	 * with third-party code.
-	 * <p/>
+	 * <p>
 	 * Please keep in mind that this only alters the way this library establishes the connection between two objects.
 	 * This doesn't extend to the underlying collections. So keep what in mind when you start merging your collections
 	 * and weird things start to happen.
-	 * <p/>
+	 * <p>
 	 * <b>WARNING</b>: Personally I'd try to avoid this feature as long as possible and only use it when there is
 	 * absolutely no other way.
 	 */

--- a/src/main/java/de/danielbechler/diff/circular/CircularReferenceConfigurer.java
+++ b/src/main/java/de/danielbechler/diff/circular/CircularReferenceConfigurer.java
@@ -21,12 +21,12 @@ import de.danielbechler.diff.ObjectDifferBuilder;
 /**
  * Allows to define how the circular reference detector compares object instances. By default it uses the equality
  * operator (`==`) which should be fine in most cases.
- * <p/>
+ * <p>
  * When dealing with object models that return copies of its properties on every access, it's possible to end up in
  * infinite loops, because even though the objects may look the same, they would be different instances. In those cases
  * it is possible to switch the instance detection mode to use the equals method instead of the equality operator. This
  * way objects will be considered to be "the same" whenever `equals` returns `true`.
- * <p/>
+ * <p>
  * This configuration interface also allows to register a custom handler for exception thrown, whenever a circular
  * reference is detected. The default handler simply logs a warning.
  *

--- a/src/main/java/de/danielbechler/diff/filtering/FilteringConfigurer.java
+++ b/src/main/java/de/danielbechler/diff/filtering/FilteringConfigurer.java
@@ -23,7 +23,7 @@ import de.danielbechler.diff.node.DiffNode;
  * Allows to exclude nodes from being added to the object graph based on criteria that are only known after the diff
  * for
  * the affected node and all its children has been determined.
- * <p/>
+ * <p>
  * Currently it is only possible to configure returnability based on the state (_added_, _changed_, _untouched_, etc.)
  * of the `DiffNode`. But this is just the beginning. Nothing speaks against adding more powerful options. It would be
  * nice for example to be able to pass some kind of matcher to determine returnability based on dynamic criteria at

--- a/src/main/java/de/danielbechler/diff/inclusion/InclusionConfigurer.java
+++ b/src/main/java/de/danielbechler/diff/inclusion/InclusionConfigurer.java
@@ -24,7 +24,7 @@ import de.danielbechler.diff.path.NodePath;
  * Excluded nodes will not be compared, to make sure their accessors won't get called. This is useful in cases where
  * getters could throw exceptions under certain conditions or when certain accessors are expensive to call or simply
  * not relevant for the use-case.
- * <p/>
+ * <p>
  * In combination with categories this allows to define sub-sets of properties, in order to compare only relevant parts
  * of an object (e.g. exclude all properties marked as _metadata_.)
  *
@@ -45,7 +45,7 @@ public interface InclusionConfigurer
 	 * Registers a custom {@link de.danielbechler.diff.inclusion.InclusionResolver}. Some objects may not be relevant
 	 * or suitable for the comparison process. Using an {@link de.danielbechler.diff.inclusion.InclusionResolver} is a
 	 * powerful and flexible way to detect and exclude those objects.
-	 * <p/>
+	 * <p>
 	 * Keep in mind that every single node in the object graph will be checked against each and every registered {@link
 	 * de.danielbechler.diff.inclusion.InclusionResolver}. If performance is important to you, make sure that calling
 	 * its methods is as cheap as possible.

--- a/src/main/java/de/danielbechler/diff/inclusion/InclusionResolver.java
+++ b/src/main/java/de/danielbechler/diff/inclusion/InclusionResolver.java
@@ -22,7 +22,7 @@ import de.danielbechler.diff.node.DiffNode;
  * This can be used to implement custom inclusion mechanisms. Some objects may not be relevant or suitable for the
  * comparison process. Using an {@link de.danielbechler.diff.inclusion.InclusionResolver} is a powerful and flexible
  * way to detect and exclude those objects.
- * <p/>
+ * <p>
  * Keep in mind that every single node in the object graph will be checked against each and every registered {@link
  * de.danielbechler.diff.inclusion.InclusionResolver}. If performance is important to you, make sure that calling its
  * methods is as cheap as possible.

--- a/src/main/java/de/danielbechler/diff/inclusion/TypePropertyAnnotationInclusionResolver.java
+++ b/src/main/java/de/danielbechler/diff/inclusion/TypePropertyAnnotationInclusionResolver.java
@@ -29,7 +29,7 @@ import static java.util.Collections.emptyList;
 /**
  * Created by Daniel Bechler.
  */
-class TypePropertyAnnotationInclusionResolver implements InclusionResolver
+public class TypePropertyAnnotationInclusionResolver implements InclusionResolver
 {
 	public boolean enablesStrictIncludeMode()
 	{

--- a/src/main/java/de/danielbechler/diff/instantiation/InstanceFactory.java
+++ b/src/main/java/de/danielbechler/diff/instantiation/InstanceFactory.java
@@ -30,7 +30,7 @@ public interface InstanceFactory
 	 * the type. In case of the latter, the {@link de.danielbechler.diff.ObjectDiffer} will automatically fallback to
 	 * instantiation via public non-arg constructor. If that also fails, an {@link TypeInstantiationException}
 	 * will be thrown.
-	 * <p/>
+	 * <p>
 	 * <b>Note from the author:</b> it wasn't an easy decision, but in the end I favored an exception over
 	 * logging a warning, because this way it is much harder to accidentally end up with incomplete merges without
 	 * noticing. If this turns out to be a problem for you, please let me know in the issue tracker. We could probably

--- a/src/main/java/de/danielbechler/diff/introspection/IntrospectionConfigurer.java
+++ b/src/main/java/de/danielbechler/diff/introspection/IntrospectionConfigurer.java
@@ -34,14 +34,14 @@ public interface IntrospectionConfigurer
 {
 	/**
 	 * When assigning new values via {@link de.danielbechler.diff.node.DiffNode} (e.g. during merging) it will
-	 * implicitly create missing instances of its parent objects along the path to the root object. By default those
+	 * implicitly create missing instances of its parent objects along the path to the root object. By default, those
 	 * instances will be created via public non-arg constructor. If that fails a {@link
 	 * de.danielbechler.diff.instantiation.TypeInstantiationException} will be thrown.
-	 * <p/>
-	 * To add support for types that need to be instantiated differently you can overide the default behavior via
+	 * <p>
+	 * To add support for types that need to be instantiated differently you can override the default behavior via
 	 * custom {@link de.danielbechler.diff.instantiation.InstanceFactory}. When doing so, don't worry about types
 	 * actually that are suitable for the default behavior, as it will automatically kick in, whenever the custom
-	 * factroy returns {@code null}.
+	 * factory returns {@code null}.
 	 *
 	 * @param instanceFactory A custom instance factory
 	 * @throws java.lang.IllegalArgumentException when the instanceFactory is null

--- a/src/main/java/de/danielbechler/diff/node/DiffNode.java
+++ b/src/main/java/de/danielbechler/diff/node/DiffNode.java
@@ -462,7 +462,7 @@ public class DiffNode
 
 	/**
 	 * If this node represents a bean property this method returns all annotations of its field.
-	 * <p/>
+	 * <p>
 	 * Only works for fields having a name that matches the name derived from the getter.
 	 *
 	 * @return The annotations of the field, or an empty set if there is no field with the name derived from the getter.
@@ -518,7 +518,7 @@ public class DiffNode
 	 * If this node represents a bean property, this method will simply return its name. Otherwise it will return the
 	 * property name of its closest bean property representing ancestor. This way intermediate nodes like those
 	 * representing collection, map or array items will be semantically tied to their container objects.
-	 * <p/>
+	 * <p>
 	 * That is especially useful for inclusion and exclusion rules. For example, when a List is explicitly included by
 	 * property name, it would be weird if the inclusion didn't also apply to its items.
 	 */


### PR DESCRIPTION
The self-closed `p` tag causes errors during Javadoc generation, and it doesn't make sense from the semantic point of view. The single `p` tag without the corresponding closing tag seems to be [the standard way](https://blog.joda.org/2012/11/javadoc-coding-standards.html) to mark paragraphs in Javadoc, and it is valid HTML 3.2.

The class `TypePropertyAnnotationInclusionResolver` had to be made public, because it is referenced in Javadoc.

